### PR TITLE
Make the font larger and darker for readability/accessibility.

### DIFF
--- a/style/css/custom.css
+++ b/style/css/custom.css
@@ -4,3 +4,12 @@ h3 {font-size: 1.931em;}
 h4 {font-size: 1.618;}
 h5 {font-size: 1.194em;}
 h6 {font-size: 1em;}
+
+body {
+  color: black;
+  font-size: initial;
+}
+code, pre {
+  font-size: .9em;
+  color: inherit;
+}


### PR DESCRIPTION
The default font color it is too light, which makes it hard to read. It's also pretty small.

This pull request changes the default colour to black, and uses the browser's default font-size settings.

Unfortunately, the default CSS style hard-codes font size (and color?) in several places. This only adjusts the font size and color for default text and code fragments, but at least it's a start.