### PR TITLE
remove dead links to now deleted 'advanced talon' page

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -246,5 +246,4 @@ drag
 Once the basics somewhat work for you, you'll likely want to improve your experience using Talon:
 
 * [Improve Recognition Accuracy](/improving_recognition_accuracy): Better accuracy never hurts. Many people have to tweak something.
-* Check the [advanced talon collection](/advanced_talon) for alternative speech recognition engines, configurations, and other stuff.
 * [Unofficial Talon Docs](/unofficial_talon_docs): learn about how to configure talon to your liking.

--- a/index.md
+++ b/index.md
@@ -18,7 +18,6 @@ The goal of this wiki is to provide information and documentation for the users 
 | help with customizing your configuration or writing Talon plugins | [Scripting and Configuration](/scripting_and_configuration) |
 | troubleshooting help | [Troubleshooting](/troubleshooting) |
 | help with deciding on a microphone or eye tracker | [Hardware](/hardware) |
-| alternative configurations and speech models | [Advanced Talon](/advanced_talon) |
 | videos of Talon in use | [Video Demos](/videos) |
 | answers to frequently asked questions | [FAQ](/FAQ) |
 


### PR DESCRIPTION
We removed the 'Advanced Talon' page https://github.com/TalonCommunity/Wiki/pull/83 but forgot to clean up links to that page. This PR removes those now dead links.