### PR TITLE
added max-width for table

### DIFF
--- a/overrides/css/custom.css
+++ b/overrides/css/custom.css
@@ -13,3 +13,4 @@ code, pre {
   font-size: .9em;
   color: inherit;
 }
+table {max-width: 70rem;}


### PR DESCRIPTION
all elements have max-width set to 70rem but not table :'( making tables on large screen use the whole screen width - not looking good