### PR TITLE
Cosmetic Improvements: Move TOC to sidebar, Remove 'Recently Changed' section, Clean up Menu

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 ---
 sidebar: true
-order: 5
+order: 6
 published: true
 ---
 

--- a/_includes/content_with_toc.html
+++ b/_includes/content_with_toc.html
@@ -9,7 +9,6 @@ Includes content with a table of contents right before the second header.
     {%- if html_headers contains next_three_characters -%}
         {%- if seen_first_header -%}
             {{ include.content | slice: 0, i }}
-            {%- include git-wiki/components/toc/toc-lib.html title="Contents:" minHeaders=1 html=content sanitize=true class="inline_toc" id="git-wiki-toc" h_min=2 h_max=3 ordered=1 -%}
             {{ include.content | slice: i, final_index }}
             {%- break -%}
         {%- else -%}

--- a/_includes/git-wiki/components/lists/page-list.html
+++ b/_includes/git-wiki/components/lists/page-list.html
@@ -3,6 +3,8 @@
     {% include {{ site.inc_before_page_list }} %}
     {% endif %}
 
+    {%- include git-wiki/components/toc/toc-lib.html title="Contents:" minHeaders=1 html=content sanitize=true class="inline_toc" id="git-wiki-toc" h_min=2 h_max=3 ordered=1 -%}
+
     {% if site.inc_after_page_list %}
     {% include {{ site.inc_after_page_list }} %}
     {% endif %}

--- a/_includes/git-wiki/components/lists/page-list.html
+++ b/_includes/git-wiki/components/lists/page-list.html
@@ -3,24 +3,6 @@
     {% include {{ site.inc_before_page_list }} %}
     {% endif %}
 
-    <span class="page-list-title">Recently Changed:</span>
-    <ul class="page-list">
-        {%- assign numPages=0 -%}
-        {%- assign items = site.html_pages | sort: 'date' %}
-        {%- for page in items %}
-        {%- if numPages >= site.show_wiki_pages_limit %}
-        {%- break %}
-        {%- endif %}
-        {%- if page.is_wiki_page != false and page.sitemap != false %}
-        <li class="page-list-item">
-            {%- assign title = page.title | default: page.name %}
-            <a href="{{ page.url | relative_url }}">{{title | escape}}</a>
-        </li>
-        {%- assign numPages = numPages | plus: 1 -%}
-        {%- endif -%}
-        {%- endfor %}
-    </ul>
-
     {% if site.inc_after_page_list %}
     {% include {{ site.inc_after_page_list }} %}
     {% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,15 +1,13 @@
-Menu (<a href="{{ site.github.repository_url }}/edit/{{site.git_branch | escape}}/_includes/sidebar.html">Edit</a>):
-
-<ul>
-  {%- comment -%} The position of each page in the sidebar is determined
-  by the "order" in their frontmatter: higher values of "order" come
-  later. Pages without orders go last. {%- endcomment -%}
-  {%- assign pages_by_order = site.pages | where:"sidebar","true" | sort: "order", "last" -%}
-  {%- for page in pages_by_order -%}
-    {%- if page.title -%}
-    <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>
-    {%- endif -%}
-  {%- endfor -%}
-  <li><a href="/CONTRIBUTING">Contributing to this Wiki</a></li>
-  <li><a href="/CODE_OF_CONDUCT">Code of Conduct</a></li>
-</ul>
+<nav>
+  <ul>
+    {%- comment -%} The position of each page in the sidebar is determined
+    by the "order" in their frontmatter: higher values of "order" come
+    later. Pages without orders go last. {%- endcomment -%}
+    {%- assign pages_by_order = site.pages | where:"sidebar","true" | sort: "order", "last" -%}
+    {%- for page in pages_by_order -%}
+      {%- if page.title -%}
+      <li><a href="{{ page.url | relative_url }}">{{ page.title }}</a></li>
+      {%- endif -%}
+    {%- endfor -%}
+  </ul>
+</nav>

--- a/getting_started.md
+++ b/getting_started.md
@@ -210,3 +210,4 @@ Once the basics somewhat work for you, you'll likely want to improve your experi
 
 * [Improve Recognition Accuracy](/improving_recognition_accuracy): Better accuracy never hurts. Many people have to tweak something.
 * [Unofficial Talon Docs](/unofficial_talon_docs): learn about how to configure talon to your liking.
+* [Software that Pairs Well with Talon](/other_integrations): Many users augment their Talon setup with other software (e.g., Vimium, aka vim for the browser)

--- a/improving_recognition_accuracy.md
+++ b/improving_recognition_accuracy.md
@@ -1,8 +1,3 @@
----
-sidebar: true
-order: 10
----
-
 # Improving Recognition Accuracy
 
 Improving recognition accuracy never hurts.  Many people even have to tweak something to get a good experience.  Here we show you what you can do.

--- a/index.md
+++ b/index.md
@@ -7,7 +7,8 @@
 Talon is free to use and ongoing development is made possible by [donations on Patreon](https://www.patreon.com/lunixbochs).
 
 ## Goal of this Wiki
-The goal of this wiki is to provide information and documentation for the users of Talon. As the software is under rapid development, this wiki is in a constant state of "work in progress". Some of this content exists temporarily until the official Talon Docs are created. This wiki is maintained by the members of the Talon community (i.e., anyone who uses Talon). Contributions are welcomed and appreciated. See the [Contributing](/CONTRIBUTING) documentation. Please keep in mind our [Code of Conduct](/CODE_OF_CONDUCT).
+
+The goal of this wiki is to provide information and documentation for the users of Talon. As the software is under rapid development, this wiki is in a constant state of "work in progress". Some of this content exists temporarily until the official Talon Docs are created.
 
 ## Wiki Navigation
 
@@ -29,3 +30,7 @@ A few notable channels:
 - `#health`: chat with others about computer health issues, share knowledge, find other folks who might be going through similar things
 - `#talon-docs`: chat about Talon documentation such as this wiki
 - `#hardware`: chat about hardware, e.g., microphones
+
+# Contributing
+
+This wiki is maintained by the members of the Talon community (i.e., anyone who uses Talon). Contributions are welcomed and appreciated. See the [Contributing](/CONTRIBUTING) documentation. Please keep in mind our [Code of Conduct](/CODE_OF_CONDUCT).

--- a/other_integrations.md
+++ b/other_integrations.md
@@ -1,8 +1,3 @@
----
-sidebar: true
-order: 6
----
-
 # Software that Pairs Well with Talon
 
 This page documents third party software that pair well with Talon.

--- a/overrides/css/custom.css
+++ b/overrides/css/custom.css
@@ -32,3 +32,7 @@ details > img {
   margin-left: auto;
   margin-right: auto;
 }
+
+#git-wiki-toc li ol {
+  margin:  0px;
+}

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 sidebar: true
-order: 5
+order: 3
 ---
 
 # Troubleshooting

--- a/videos.md
+++ b/videos.md
@@ -1,6 +1,6 @@
 ---
 sidebar: true
-order: 6
+order: 5
 published: true
 ---
 


### PR DESCRIPTION
- Remove 'Recently Changed' Section
- Move TOC (Table of Contents) into sidebar
- Fix margin inconsistency with TOC
- Remove 'Edit' button for Menu, this isn't really useful anymore
- Turn 'Menu' into a nav bar. This is a sort of interim stage getting us closer to having it feel more like a real nav bar on the page.