### PR TITLE
Update git_branch in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ permalink: pretty
 show_downloads: true
 repository: TalonCommunity/Wiki
 # (string) Specify branch rendered by gitpages allowing wiki tool buttons to work
-git_branch: "gh-pages"
+git_branch: "main"
 # (string) Url of logo image, it can be full, absolute or relative.
 logo_url: 
 # (string) The UA-XXXXX-Y code from google analytic to enable GA on your wiki


### PR DESCRIPTION
As part of the migration from github pages to netlify, we changed the default
branch of the repo to be 'main' instead of 'gh-pages'. The git_branch setting
in _config.yml needs to be updated to the new default branch for the wiki tools
buttons to continue to work.