### PR TITLE
Remove github metadata dependency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,11 @@ permalink: pretty
 # (boolean) Enable/disable download buttons in sidebar
 show_downloads: true
 repository: TalonCommunity/Wiki
-# (string) Specify branch rendered by gitpages allowing wiki tool buttons to work
+# (string) Specify github metadata allowing wiki tool buttons to work
+git_hostname: "github.com"
+git_owner_url: "https://github.com/TalonCommunity"
+git_owner_name: "TalonCommunity"
+repository_url: "https://github.com/TalonCommunity/Wiki"
 git_branch: "main"
 # (string) Url of logo image, it can be full, absolute or relative.
 logo_url: 

--- a/_includes/custom.html
+++ b/_includes/custom.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="{{ 'overrides/css/custom.css?v=' | append: site.github.build_revision | relative_url }}">
+<link rel="stylesheet" href="{{ 'overrides/css/custom.css?v=' | append: relative_url }}">

--- a/_includes/git-wiki/components/action_btn/downloads.html
+++ b/_includes/git-wiki/components/action_btn/downloads.html
@@ -1,3 +1,3 @@
 <ul class="git-wiki-downloads">
-    <li><a href="{{ site.github.repository_url }}">View On <strong>{% if site.github.hostname == "gitlab.com" %} Gitlab {% else %} Github {% endif %} </strong></a></li>
+    <li><a href="{{ site.repository_url }}">View On <strong>Github</strong></a></li>
 </ul>

--- a/_includes/git-wiki/components/action_btn/page_actions.html
+++ b/_includes/git-wiki/components/action_btn/page_actions.html
@@ -1,36 +1,36 @@
 <div class="git-wiki-tools">
     {% if site.use_github_wiki %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/_new">Add new</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/{{url | remove: '.html' | append: ''}}/_edit">Edit</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/{{url | remove: '.html' | append: ''}}/_history">History</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/{{url | remove: '.html' | append: '.md'}}/">Source</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/wiki/_new">Add new</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/wiki/{{url | remove: '.html' | append: ''}}/_edit">Edit</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/wiki/{{url | remove: '.html' | append: ''}}/_history">History</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/wiki/{{url | remove: '.html' | append: '.md'}}/">Source</a></span>
     {% else %}
     {% if site.wiki_folder == "" %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}">Add new</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/new/{{site.git_branch | escape}}">Add new</a></span>
     {% else %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.site_root | default: '/' }}{{ site.wiki_folder }}/">Add
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.site_root | default: '/' }}{{ site.wiki_folder }}/">Add
             new</a></span>
     {% endif %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/edit/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
-    {% if site.github.hostname == "gitlab.com" %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Delete</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/edit/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
+    {% if site.git_hostname == "gitlab.com" %}
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Delete</a></span>
     {% else %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/delete/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Delete</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/delete/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Delete</a></span>
     {% endif %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/commits/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">History</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Source</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/commits/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">History</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/blob/{{site.git_branch | escape}}/{{ site.site_root | default: '/' }}{{page.path | escape}}">Source</a></span>
     {% if site.blog_feature %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.site_root | default: '/' }}_posts/">Add
+    <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.site_root | default: '/' }}_posts/">Add
             new post</a></span>
     {% endif %}
-    {% if site.use_prose_io and site.github.hostname != "gitlab.com" %}
+    {% if site.use_prose_io and site.git_hostname != "gitlab.com" %}
     <br>
     Prose.io:
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}">Add
             new</a></span>
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
     {% if site.blog_feature %}
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}_posts/">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}_posts/">Add
             new post</a></span>
     {% endif %}
     {% endif %}

--- a/_includes/git-wiki/components/copyrights/copyrights.html
+++ b/_includes/git-wiki/components/copyrights/copyrights.html
@@ -1,11 +1,5 @@
-{% if site.github.is_project_page %}
 <div class="git-wiki-copyrights">
-    <p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-    {% endif %}
-    <p><small>Hosted on GitHub Pages &mdash; Powered by <a href="https://github.com/Drassil/git-wiki-theme">Git-Wiki v{{
-                version }}</a> </p>
+    <p>This project is maintained by <a href="{{ site.git_owner_url }}">{{ site.git_owner_name }}</a></p>
 
-    {% if site.github.is_project_page %}
-    <p class="view"><a href="{{ site.github.repository_url }}">View the Project on {% if site.github.hostname == "gitlab.com" %} Gitlab {% else %} Github {% endif %} <small>{{ github_name }}</small></a></p>
+    <p class="view"><a href="{{ site.repository_url }}">View the Project on Github<small>{{ github_name }}</small></a></p>
 </div>
-{% endif %}

--- a/_includes/git-wiki/components/logo/logo.html
+++ b/_includes/git-wiki/components/logo/logo.html
@@ -1,6 +1,6 @@
 <div class="git-wiki-main-logo">
 <a href="{{ '/' | relative_url }}"><img src="{{ site.logo_url | relative_url }}">
-        <h1>{{ site.title | default: site.github.repository_name | escape }}</h1>
+        <h1>{{ site.title | escape }}</h1>
     </a>
-    <p>{{ site.description | default: site.github.project_tagline }}</p>
+    <p>{{ site.description }}</p>
 </div>

--- a/_includes/git-wiki/components/search/se_github.html
+++ b/_includes/git-wiki/components/search/se_github.html
@@ -1,5 +1,5 @@
 <div class="git-wiki-search-github">
-    <form method="GET" action="{{ site.github.repository_url }}/search">
+    <form method="GET" action="{{ site.repository_url }}/search">
         <input type="text" name="q[]" placeholder="Text to search">
         {% if site.use_github_wiki %}
         <input type="hidden" name="type" value="Wikis">

--- a/_includes/git-wiki/sections/head/styles.html
+++ b/_includes/git-wiki/sections/head/styles.html
@@ -2,7 +2,7 @@
 {% include {{ site.inc_before_styles }} %}
 {% endif %}
 
-<link rel="stylesheet" href="{{ '/assets/css/git-wiki-style.css?v=' | append: site.github.build_revision | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/git-wiki-style.css?v=' | append: relative_url }}">
 
 {% if site.inc_after_styles %}
 {% include {{ site.inc_after_styles }} %}

--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -22,11 +22,6 @@
       {% endif %}
     </div>
 
-
-    {% if site.github.is_user_page %}
-    <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
-    {% endif %}
-
     {% if site.show_wiki_pages %}
     {% include git-wiki/components/lists/page-list.html %}
     {% endif %}

--- a/_layouts/git-wiki-404.html
+++ b/_layouts/git-wiki-404.html
@@ -10,6 +10,6 @@ is_wiki_page: false
     if (!filename.endsWith(".md"))
         filename+=".md";
 
-    var url = '{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.wiki_folder | default: 'wiki' }}/'+filename;
+    var url = '{{ site.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.wiki_folder | default: 'wiki' }}/'+filename;
     window.location=url;
 </script>

--- a/_layouts/git-wiki-bs-github.html
+++ b/_layouts/git-wiki-bs-github.html
@@ -19,7 +19,7 @@
     {% include git-wiki/sections/head/styles.html %}
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.1.3/united/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ '/assets/css/github.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/github.css?v=' | append: relative_url }}">
 
     {% if site.inc_after_head %}
     {% include {{ site.inc_after_head }} %}


### PR DESCRIPTION
The github metadata, such as site.github.repository and site.github.hostname,
is populated by github pages. Since we are no longer deploying using github
pages, then we cannot use these variables. Instead, create our own config
variables to replace them. For some of these references, we already were using
a config variable, so I removed the github metadata option.