### PR TITLE
fix prose links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ git_hostname: "github.com"
 git_owner_url: "https://github.com/TalonCommunity"
 git_owner_name: "TalonCommunity"
 repository_url: "https://github.com/TalonCommunity/Wiki"
+git_repository_nwo: "TalonCommunity/Wiki"
 git_branch: "main"
 # (string) Url of logo image, it can be full, absolute or relative.
 logo_url: 
@@ -41,7 +42,7 @@ wiki_folder: ""
 use_github_wiki: false
 # (boolean) Enable "Edit with Prose.io" button in tools, it's a 3rd party
 # service to edit github markdown pages easily
-use_prose_io: true
+use_prose_io: false
 # Select search_engine component from:
 # - js: it uses a built in javascript component that uses generated js object
 # - js_rss: it uses a built in javascript component that uses generated  sitemap_full.xml to search inside your wiki with lunr library (slow and experimental)

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ wiki_folder: ""
 use_github_wiki: false
 # (boolean) Enable "Edit with Prose.io" button in tools, it's a 3rd party
 # service to edit github markdown pages easily
-use_prose_io: false
+use_prose_io: true
 # Select search_engine component from:
 # - js: it uses a built in javascript component that uses generated js object
 # - js_rss: it uses a built in javascript component that uses generated  sitemap_full.xml to search inside your wiki with lunr library (slow and experimental)

--- a/_includes/git-wiki/components/action_btn/page_actions.html
+++ b/_includes/git-wiki/components/action_btn/page_actions.html
@@ -23,14 +23,14 @@
     <span class="tools-element"><a target="_blank" href="{{ site.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.site_root | default: '/' }}_posts/">Add
             new post</a></span>
     {% endif %}
-    {% if site.use_prose_io and site.git_hostname != "gitlab.com" %}
+    {% if site.use_prose_io %}
     <br>
     Prose.io:
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.git_repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{ site.wiki_folder }}">Add
             new</a></span>
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.git_repository_nwo}}/edit/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}{{page.path | escape}}">Edit</a></span>
     {% if site.blog_feature %}
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}_posts/">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.git_repository_nwo}}/new/{{site.git_branch | escape}}{{ site.site_root | default: '/' }}_posts/">Add
             new post</a></span>
     {% endif %}
     {% endif %}


### PR DESCRIPTION
`site.repository_nwo` is also a github metadata field (that is no longer populated now that we don't use github pages). Replace it with a new config variable to (hopefully) restore the prose links.