### PR TITLE
Make inline code snippets more visually prominent

### DIFF
--- a/_sass/git-wiki-style.scss
+++ b/_sass/git-wiki-style.scss
@@ -87,6 +87,10 @@ pre {
   font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
   color: #333;
   font-size: 12px;
+  border: 1px solid #e5e5e5;
+  background: #f8f8f8;
+  padding: 3px;
+  border-radius: 3px;
 }
 
 pre {
@@ -95,6 +99,10 @@ pre {
   border-radius: 5px;
   border: 1px solid #e5e5e5;
   overflow-x: auto;
+}
+
+pre > code {
+  border: none;
 }
 
 table {

--- a/_sass/git-wiki-style.scss
+++ b/_sass/git-wiki-style.scss
@@ -89,7 +89,7 @@ pre {
   font-size: 12px;
   border: 1px solid #e5e5e5;
   background: #f8f8f8;
-  padding: 3px;
+  padding: 2px;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Inline code elements were quite hard to read prior to these changes as they weren't visually distinct enough from regular text. These changes are a few tweaks to the css to make them more distinct.

We could go further to make them stand out even more (like a different color rather than a subtle gray?), but these were the quickest fix for now. The whole site needs some aesthetic attention soon anyway, so a quicker fix now seems better than a perfect one.