### PR TITLE
use absolute path to include custom css (and fix few other bonus broken links)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -9,8 +9,8 @@ published: true
 ### What can I say?  
 Checkout the [common commands](/getting_started/#basic-usage) to get started using Talon.
 
-### How can I code with Talon
-After you're comfortable with the basic operations above, you can [activate your programming language](/scripting_and_configuration/#activating-your-programming-language).
+### How can I code in different languages with Talon
+Talon does not require special configuration for different programming languages, but many users have per-language customizations to improve efficiency. Checkout the section on [Programming Languages](/unofficial_talon_docs#talon-settings) in the knausj repository README for more information on how to use different language modes included in knausj.
 
 ### What hardware should I have?
 Check out the [hardware](/hardware) page for microphone and eye tracker recommendations.  

--- a/_includes/custom.html
+++ b/_includes/custom.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="{{ 'overrides/css/custom.css?v=' | append: relative_url }}">
+<link rel="stylesheet" href="{{ '/overrides/css/custom.css?v=' }}">

--- a/_includes/git-wiki/sections/head/scripts.html
+++ b/_includes/git-wiki/sections/head/scripts.html
@@ -5,9 +5,6 @@
 <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
     crossorigin="anonymous"></script>
 <script src="{{ '/assets/js/checkLinks.js' | relative_url }}"></script>
-<!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
 {% if site.inc_after_scripts %}
 {% include {{ site.inc_after_scripts }} %}

--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -278,7 +278,7 @@ TODO: are there any interesting arguments to Module?
 
 ### Contexts
 
-A *context* specifies conditions under which to add new behavior or override existing behavior. The conditions a context can check for [several properties](/unofficial_talon_docs#context-header), like your OS, the name of the current application, etc.  Within a particular context, you can do everything you can do in a `.talon` file: define voice commands, implement/override the behavior of [actions](/unofficial_talon_docs#actions), adjust [settings](https://talon.wiki/talon-settings/), and activate [tags](/unofficial_talon_docs#tags).
+A *context* specifies conditions under which to add new behavior or override existing behavior. The conditions a context can check for [several properties](/unofficial_talon_docs#context-header), like your OS, the name of the current application, etc.  Within a particular context, you can do everything you can do in a `.talon` file: define voice commands, implement/override the behavior of [actions](/unofficial_talon_docs#actions), adjust [settings](/unofficial_talon_docs#talon-settings), and activate [tags](/unofficial_talon_docs#tags).
 
 In Python, you can construct a context like so:
 


### PR DESCRIPTION
This PR fixes a few broken links, including the link to the custom css from any page except the index.

In addition to fixing the custom css loading, this PR includes fixes for other broken links identified by a Netlify plugin.