### PR TITLE
Additions to scripting page

### DIFF
--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -246,20 +246,20 @@ Talon files can also adjust settings; for more on this see [Talon Settings](/uno
 
 Although Talon files are the primary way of extending Talon, there are some things that they can't do. In particular, they can't:
 
-1. Declare [actions](/unofficial_talon_docs#actions), although they can implement and invoke them.
+1. Declare [actions](/unofficial_talon_docs#actions), although they can invoke them. They can also currently implement them, but this is deprecated.
 2. Declare or override [lists](/unofficial_talon_docs#lists), although they can use them in rules.
 3. Declare or implement [captures](/unofficial_talon_docs#captures), although they can use them in rules.
 4. Run arbitrary Python code.
 
 For those things you need Python files, which may also be placed in `~/.talon/user/` or its subdirectories. A good way to start most Talon Python files is:
 
-```
+```python
 from talon import Module, Context
 mod = Module()
 ctx = Context()
 ```
 
-This sets you up with a module `mod` for declaring actions, lists, and captures; and a context `ctx` for implementing or overriding actions, lists, and captures, and otherwise doing whatever you could do in a Talon file. For more documentation on this, see [Talon Concepts](/unofficial_talon_docs#talon-concepts/).
+This sets you up with a module `mod` for declaring actions, lists, and captures; and a context `ctx` for implementing or overriding actions, lists, and captures. For more documentation on this, see [Talon Concepts](/unofficial_talon_docs#talon-concepts/).
 
 ## Talon Concepts
 
@@ -278,11 +278,11 @@ TODO: are there any interesting arguments to Module?
 
 ### Contexts
 
-A *context* specifies conditions under which to add new behavior or override existing behavior. The conditions a context can check for [several properties](/unofficial_talon_docs#context-header), like your OS, the name of the current application, etc.  Within a particular context, you can do everything you can do in a `.talon` file: define voice commands, implement/override the behavior of [actions](/unofficial_talon_docs#actions), adjust [settings](/unofficial_talon_docs#talon-settings), and activate [tags](/unofficial_talon_docs#tags).
+A *context* specifies conditions under which to add new behavior or override existing behavior. The conditions a context can check for [several properties](/unofficial_talon_docs#context-header), like your OS, the name of the current application, etc.  Within a particular context, you can define voice commands, implement/override the behavior of [actions](/unofficial_talon_docs#actions), adjust [settings](/unofficial_talon_docs#talon-settings), and activate [tags](/unofficial_talon_docs#tags). Note that you cannot define new voice commands in Python, that can only be done in `.talon` files.
 
 In Python, you can construct a context like so:
 
-```
+```python
 from talon import Context
 ctx = Context()
 ```
@@ -290,7 +290,7 @@ ctx = Context()
 When initially constructed, a context has no conditions attached, and so it is always active.
 You can make this context conditional by setting `matches`:
 
-```
+```python
 ctx.matches = "mode: command"
 ```
 

--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -43,6 +43,7 @@ insert code fragment:
     key(up)
 
 # This says how to implement the actions app.tab_next and app.tab_previous.
+# Note that implementing actions in .talon files is deprecated. See the Actions section below for the supported syntax.
 action(app.tab_next): key(ctrl-tab)
 action(app.tab_previous): key(shift-ctrl-tab)
 
@@ -135,16 +136,6 @@ Rules have a versatile syntax that is like a word based regex:
 | `(foo)` | Precedence/grouping | “foo” |
 | `{some_list}` | [List](/unofficial_talon_docs/#lists) | Depends on the list. |
 | `<some_capture>` | [Capture](/unofficial_talon_docs/#captures) | Depends on the capture. |
-
-### Implementing actions
-
-In place of an ordinary rule, you can also implement an [action](/unofficial_talon_docs#actions). In this case the rule has the form `action(NAME_OF_ACTION)`. The body syntax is the same. For example:
-
-```
-action(app.tab_next): key(ctrl-tab)
-```
-
-This means whenever this file's context applies and the action `app.tab_next` is invoked by a Talon voice command, it will press the shortcut ctrl-tab -- unless that action is overridden in some more specific context.
 
 ### Tags
 
@@ -385,7 +376,7 @@ Scopes allow you to supply additional properties that can be matched in the head
 You need to write custom Python code to keep your scope information up to date. The following example implements a scope that makes the current time available as a matcher property.
 
 `test.py`
-```
+```python
 import datetime
 from talon import Module, cron
 


### PR DESCRIPTION
I fixed a couple of minor errors, mentioned that implementing actions in .talon files is deprecated, and added some examples to the .talon file section and Actions section.