### PR TITLE
Remove references to speech.record_all

### DIFF
--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -566,7 +566,7 @@ TODO: What is the REPL, how do you get and use logging?
 
 ### Introspection functions
 
-This section lists some built in methods which are useful for developing or debugging Talon behaviour. See also the `speech.debug` and `speech.record_all` settings described in the [Built in Talon settings](#) section.
+This section lists some built in methods which are useful for developing or debugging Talon behaviour. See also the `speech.debug` setting described in the [Built in Talon settings](#) section.
 
 
 `actions.find('user.my_action')`
@@ -610,6 +610,3 @@ The following three settings, `insert_wait`, `key_hold`, and `key_wait`, can be 
 : This determines how long a pause Talon waits for before deciding you've finished speaking and interpreting what you've just said as a sequence of commands. This parameter is generally very important; for example, it determines the the amount of time you can pause between saying 'phrase' and the following phrase.
 
   It is measured in seconds; the default is 0.150, i.e. 150 milliseconds. It has been mentioned in #beta that this setting may not always be available as it was offered as a quick fix in Talon 1283 for Talon 1274 cutting input off too soon sometimes.
-
-`speech.record_all`
-: If set to 1, all phrases Talon hears will be stored in a `.flac` file on your computer.  You can use this to analyze microphone issues, or it might be useful to analyze speech engine issues. The default value is 0.


### PR DESCRIPTION
This setting is available in the menu now. Defining it by hand messes with the
menu item, so remove references to setting this by hand.