### PR TITLE
Update Talon Slack links to use https://talonvoice.com/chat

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -17,7 +17,7 @@ Check out the [hardware](/hardware) page for microphone and eye tracker recommen
 
 ### Are languages other than English supported?
 
-They're being worked on, join talonvoice.slack.com and find a channel for your language to see how it's going. If you are in the beta program, you can configure the WebSpeech API for dictation in other languages.
+They're being worked on, join [Talon Slack](https://talonvoice.com/chat) and find a channel for your language to see how it's going. If you are in the beta program, you can configure the WebSpeech API for dictation in other languages.
 
 ### How can I make talon recognise me better?
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -21,7 +21,7 @@ The official installation and getting started instructions are available at [tal
 Talon has two mostly compatible current versions: public and beta. Both versions have support for Mac, Linux, and Windows.
 
 * **Public Version (free):** Follow [Getting Started](https://talonvoice.com/docs/index.html#getting-started) instructions in the Talon documentation.
-* **Beta Version (requires Patreon support):** The beta version has earlier access to new features and higher priority support. It is required for access to some speech engines. After becoming a [beta tier Patreon](https://www.patreon.com/join/lunixbochs), join the [Talon Voice Slack](https://talonvoice.slack.com) and request access to the `#beta` channel from `@aegis`, the developer of Talon. Download links can be found in the #beta channel's pinned messages.
+* **Beta Version (requires Patreon support):** The beta version has earlier access to new features and higher priority support. It is required for access to some speech engines. After becoming a [beta tier Patreon](https://www.patreon.com/join/lunixbochs), join the [Talon Voice Slack](https://talonvoice.com/chat) and request access to the `#beta` channel from `@aegis`, the developer of Talon. Download links can be found in the #beta channel's pinned messages.
 
 ### Notes on Linux
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -14,7 +14,7 @@ The official installation and getting started instructions are available at [tal
 1. Choose a [speech recognition engine](https://talon.wiki/getting_started/#configure-a-speech-recognition-engine).
 1. Install a [configuration set](https://talon.wiki/getting_started/#install-a-talon-configuration-set), to make some commands available.
 1. Try some [basic commands](/getting_started#basic-usage)
-1. Optionally, join the [Talon Voice Slack](https://talonvoice.slack.com) for help, tips, and connecting with other Talon users.
+1. Optionally, join the [Talon Voice Slack](https://talonvoice.com/chat) for help, tips, and connecting with other Talon users.
 
 ## Install Talon
 


### PR DESCRIPTION
Using `https://talonvoice.com/chat` to link to the Talon Slack directs users to a sign up flow, which we want. Replace all links to Talon Slack to use this url.

Unfortunately, for folks who already use slack it will also direct them to the sign up page without a link to sign in, but I'm not sure there are many folks who are already part of the Slack that will want to use these links. For now, let's make sure new users get the right flow.

In the future, we _could_ link to Slack section on the wiki which would have both links, but this is good enough for now.