### PR TITLE
Fixed line that didn't render correctly on mobile

### DIFF
--- a/basic_customization.md
+++ b/basic_customization.md
@@ -154,7 +154,7 @@ You might have noticed that we've been using the key() and insert() actions in t
 
 1. Right click on the Talon icon in your status bar, choose scripting, and then 'Console (REPL)'. This will open a terminal window where you type Python commands and the result of those commands are printed out.
 2. Type `actions.list()` and press enter. This will list out all the available actions.
-3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter: `import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old`. You can then paste the list of actions wherever you like.
+3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter: ```import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old```.
 
 Some of the more useful actions are:
 

--- a/basic_customization.md
+++ b/basic_customization.md
@@ -154,7 +154,9 @@ You might have noticed that we've been using the key() and insert() actions in t
 
 1. Right click on the Talon icon in your status bar, choose scripting, and then 'Console (REPL)'. This will open a terminal window where you type Python commands and the result of those commands are printed out.
 2. Type `actions.list()` and press enter. This will list out all the available actions.
-3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter: ```import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old```.
+3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter:
+
+```import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old ```
 
 Some of the more useful actions are:
 

--- a/basic_customization.md
+++ b/basic_customization.md
@@ -156,7 +156,9 @@ You might have noticed that we've been using the key() and insert() actions in t
 2. Type `actions.list()` and press enter. This will list out all the available actions.
 3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter:
 
-```import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old ```
+```
+import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old
+```
 
 Some of the more useful actions are:
 


### PR DESCRIPTION
The line that was edited was to long in mobile and because it was in a single backtick it didn't wrap around. This update changes it to be a triple backtick that hopefully will render correctly.