### PR TITLE
fix: Set padding-right: 0px for #git-wiki-sidebar

### DIFF
--- a/_sass/git-wiki-style.scss
+++ b/_sass/git-wiki-style.scss
@@ -288,7 +288,7 @@ screen and (max-width: 960px) {
   }
 
   #git-wiki-sidebar {
-    padding-right: 320px;
+    padding-right: 0px;
   }
 
   .git-wiki-page,


### PR DESCRIPTION
Fixes display issue on screen sizes from 720px to 960px where nav drawer links stack ontop of eachother.

https://i.imgur.com/rjTXPLB.png