### PR TITLE
fix: Remove outline from .w3-bar-item & block

### DIFF
--- a/_sass/w3.scss
+++ b/_sass/w3.scss
@@ -493,7 +493,6 @@ a {
   border: none;
   white-space: normal;
   float: none;
-  outline: 0;
 }
 .w3-bar-block.w3-center .w3-bar-item {
   text-align: center;


### PR DESCRIPTION
Remove outline property to allow for focus highlighting on Close button during tab press.

Before: https://i.imgur.com/O8Fm3IV.png
After: https://i.imgur.com/BBZkYQW.png