### PR TITLE
fix: Normalize media query width to 992px

### DIFF
--- a/_sass/git-wiki-style.scss
+++ b/_sass/git-wiki-style.scss
@@ -272,7 +272,7 @@ footer {
 }
 
 @media print,
-screen and (max-width: 960px) {
+screen and (max-width: 992px) {
 
   div.wrapper {
     width: auto;


### PR DESCRIPTION
This is the only media query at 960px, changing to 992px fixes a padding jump when scaling window from large to medium screen sizes.