### PR TITLE
feat: Rework sidebar open/close functions

### DIFF
--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -1,9 +1,9 @@
 <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
-  <button class="w3-button w3-teal" onclick="sidebar_open()">&#9776;</button>
-  <a href="{{ '/' | relative_url }}">
+  <button class="w3-button w3-teal" id="button-open-sidebar">&#9776;</button>
+  <a href="{{ '/' | relative_url }}"> 
     {% if site.logo_url %}
     <img src="{{ site.logo_url | relative_url }}" width="20px">
-    {% endif %}
+    {% https://github.com/Spiteless/Wiki/tree/patch-4/_includesendif %}
     {{ site.title | escape }}
   </a>
 </div>
@@ -40,15 +40,31 @@
   </div>
 </header>
 <script>
+  const sidebar = document.getElementById("git-wiki-sidebar");
+  const sidebar_open_button = document.getElementById("button-open-sidebar");
+
+  function sidebar_open(event) {
+    //if sidebar is active, allow button click to close sidebar
+    if (!sidebar_open_button.classList.contains("sidebar-open")) {
+      event.stopPropagation(); //prevents bubble effect, stopping sidebar_close() on document event listener
+      sidebar_open_button.classList.add("sidebar-open");
+      sidebar.style.display = "block";
+    }
+  }
+
+  function sidebar_close() {
+    sidebar_open_button.classList.remove("sidebar-open");
+    sidebar.style.display = "none";
+    sidebar.style.position = "inherit";
+  }
+
   document.addEventListener(
     "click",
     function (event) {
-      // If user either clicks Close button OR clicks outside
-      // the sidebar window OR clicks a link, then sidebar_close() 
       if (
-        event.target.matches("#button-close-sidebar") ||
-        !event.target.closest(".w3-sidebar") ||
-        event.target.matches("a")
+        event.target.matches("#button-close-sidebar") || //user clicks close button
+        !event.target.closest(".w3-sidebar") || //user clicks outside sidebar
+        event.target.matches("a") //user clicks a link (for internal page navigation)
       ) {
         sidebar_close();
       }
@@ -62,14 +78,5 @@
     }
   });
 
-  function sidebar_open() {
-    var sidebar = document.getElementById("git-wiki-sidebar");
-    sidebar.style.display = "block";
-  }
-
-  function sidebar_close() {
-    var sidebar = document.getElementById("git-wiki-sidebar");
-    sidebar.style.display = "none";
-    sidebar.style.position = "inherit";
-  }
+  sidebar_open_button.addEventListener("click", sidebar_open, false);
 </script>

--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -44,10 +44,11 @@
     "click",
     function (event) {
       // If user either clicks Close button OR clicks outside
-      // the sidebar, then sidebar_close()
+      // the sidebar window OR clicks a link, then sidebar_close() 
       if (
         event.target.matches("#button-close-sidebar") ||
-        !event.target.closest(".w3-sidebar")
+        !event.target.closest(".w3-sidebar") ||
+        event.target.matches("a")
       ) {
         closeSidebar();
       }

--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -1,5 +1,5 @@
 <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
-  <button class="w3-button w3-teal" onclick="openSidebar()">&#9776;</button>
+  <button class="w3-button w3-teal" onclick="sidebar_open()">&#9776;</button>
   <a href="{{ '/' | relative_url }}">
     {% if site.logo_url %}
     <img src="{{ site.logo_url | relative_url }}" width="20px">
@@ -9,7 +9,7 @@
 </div>
 <header class="w3-sidebar w3-bar-block w3-collapse" id="git-wiki-sidebar">
   <div>
-    <button class="w3-bar-item w3-button w3-large w3-hide-large" id="button-close-sidebar" onclick="closeSidebar()">Close &times;</button>
+    <button class="w3-bar-item w3-button w3-large w3-hide-large" id="button-close-sidebar" onclick="sidebar_close()">Close &times;</button>
     {% if site.inc_before_header %}
     {% include {{ site.inc_before_header }} %}
     {% endif %}
@@ -50,7 +50,7 @@
         !event.target.closest(".w3-sidebar") ||
         event.target.matches("a")
       ) {
-        closeSidebar();
+        sidebar_close();
       }
     },
     false
@@ -58,16 +58,16 @@
 
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape") {
-      closeSidebar();
+      sidebar_close();
     }
   });
 
-  function openSidebar() {
+  function sidebar_open() {
     var sidebar = document.getElementById("git-wiki-sidebar");
     sidebar.style.display = "block";
   }
 
-  function closeSidebar() {
+  function sidebar_close() {
     var sidebar = document.getElementById("git-wiki-sidebar");
     sidebar.style.display = "none";
     sidebar.style.position = "inherit";

--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -1,5 +1,5 @@
 <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
-  <button class="w3-button w3-teal" onclick="sidebar_toggle()">&#9776;</button>
+  <button class="w3-button w3-teal" onclick="openSidebar()">&#9776;</button>
   <a href="{{ '/' | relative_url }}">
     {% if site.logo_url %}
     <img src="{{ site.logo_url | relative_url }}" width="20px">
@@ -9,7 +9,7 @@
 </div>
 <header class="w3-sidebar w3-bar-block w3-collapse" id="git-wiki-sidebar">
   <div>
-    <button class="w3-bar-item w3-button w3-large w3-hide-large" onclick="sidebar_toggle()">Close &times;</button>
+    <button class="w3-bar-item w3-button w3-large w3-hide-large" id="button-close-sidebar" onclick="closeSidebar()">Close &times;</button>
     {% if site.inc_before_header %}
     {% include {{ site.inc_before_header }} %}
     {% endif %}
@@ -40,13 +40,35 @@
   </div>
 </header>
 <script>
-  function sidebar_toggle() {
-    var sidebar = document.getElementById("git-wiki-sidebar");
-    if (sidebar.style.display == "block") {
-      sidebar.style.display = "none";
-      sidebar.style.position = "inherit";
-    } else {
-      $(sidebar).attr('style', 'display: block;');
+  document.addEventListener(
+    "click",
+    function (event) {
+      // If user either clicks Close button OR clicks outside
+      // the sidebar, then sidebar_close()
+      if (
+        event.target.matches("#button-close-sidebar") ||
+        !event.target.closest(".w3-sidebar")
+      ) {
+        closeSidebar();
+      }
+    },
+    false
+  );
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeSidebar();
     }
+  });
+
+  function openSidebar() {
+    var sidebar = document.getElementById("git-wiki-sidebar");
+    sidebar.style.display = "block";
+  }
+
+  function closeSidebar() {
+    var sidebar = document.getElementById("git-wiki-sidebar");
+    sidebar.style.display = "none";
+    sidebar.style.position = "inherit";
   }
 </script>


### PR DESCRIPTION
Split sidebar_toggle() into sidebar_close() and sidebar_open()

Add event listener to sidebar_close() when user clicks outside the sidebar Add event listener to sidebar_close() on "esc" press