### PR TITLE
fix: Remove 99% width on small screens for #git-wiki-downloads

### DIFF
--- a/overrides/css/custom.css
+++ b/overrides/css/custom.css
@@ -43,3 +43,9 @@ details > img {
   padding-left: 1rem;
   margin-bottom: 0;
 }
+
+@media print, screen and (max-width: 480px) {
+  #git-wiki-sidebar .git-wiki-downloads {
+    width: 89px;
+  }
+}


### PR DESCRIPTION
Old width on small screens results in stretched container, keeping value at 89px prevents this

See image:
https://i.imgur.com/Ont36Je.png