### PR TITLE
Add Fluent Search

### DIFF
--- a/other_integrations.md
+++ b/other_integrations.md
@@ -14,8 +14,9 @@ This page documents third party software that pair well with Talon.
 | --- | --- | --- | --- |
 | [Shortcat](https://shortcatapp.com/) | Free | Mac | Allows selecting native UI elements by searching related strings. Like vimium for OSX. |
 | [Homerow](https://www.homerow.app) | Paid | Mac | Another Vimium for OSX alternative. |
-| [Hunt and Peck](https://github.com/zsims/hunt-and-peck) | Free | Windows | Like Vimium for Windows. Paints a two letter label on each button etc. which you can type to select. |
 | [Rectangle](https://github.com/rxhanson/Rectangle) | Free | Mac | Keyboard control window placement and management |
+| [Fluent Search](https://fluentsearch.net/) | Free | Windows |  General Windows productivity software that can put labels on each button etc. (in addition to acting as an application launcher). Highly customizable and feature rich. |
+| [Hunt and Peck](https://github.com/zsims/hunt-and-peck) | Free | Windows | Like Vimium for Windows. Paints a two letter label on each button etc. which you can type to select. Note: May not work with some modern Windows GUI programs. Sporadically maintained |
 
 ## Browser navigation
 


### PR DESCRIPTION
Hunt and peck  is to my understanding no longer the preferred option for screen search akin to vimium on windows. Fluent search seems to be a better alternative for modern windows applications and is generally better maintained with more customizability.  In the readme for hunt and peck  it specifically mentions that it is sporadically maintained and doesn't work with all modern applications.

I still have both of these options in here though  in case fluent search doesn't work for someone for some reason.

 This was mentioned in the windows channel and thought it would be useful to document here publicly