### PR TITLE
basic_usage.md: use recommended sleep commands

### DIFF
--- a/basic_usage.md
+++ b/basic_usage.md
@@ -46,7 +46,7 @@ There are currently no visual cues about the current mode. You can tell which mo
 `go to sleep`
 : go to sleep, stop processing commands (you can also use `talon sleep` to disambiguate when using Dragon)
 
-`talon wake`
+`wake up`
 : wake up and return to previous mode (you can also use `talon wake` to disambiguate when using Dragon)
 
 

--- a/basic_usage.md
+++ b/basic_usage.md
@@ -44,10 +44,10 @@ There are currently no visual cues about the current mode. You can tell which mo
 : switch to command mode
 
 `go to sleep`
-: go to sleep, stop processing commands (you can also use `talon sleep` when using Dragon)
+: go to sleep, stop processing commands (you can also use `talon sleep` to disambiguate when using Dragon)
 
 `talon wake`
-: wake up and return to previous mode (you can also use `talon wake` when using Dragon)
+: wake up and return to previous mode (you can also use `talon wake` to disambiguate when using Dragon)
 
 
 ### Open and switch between windows in apps such as Chrome

--- a/basic_usage.md
+++ b/basic_usage.md
@@ -43,11 +43,11 @@ There are currently no visual cues about the current mode. You can tell which mo
 `command mode`
 : switch to command mode
 
-`talon sleep`
-: go to sleep, stop processing commands
+`go to sleep`
+: go to sleep, stop processing commands (you can also use `talon sleep` when using Dragon)
 
 `talon wake`
-: wake up and return to previous mode
+: wake up and return to previous mode (you can also use `talon wake` when using Dragon)
 
 
 ### Open and switch between windows in apps such as Chrome


### PR DESCRIPTION
See https://github.com/chaosparrot/talon_practice/issues/11. `wake up` and `go to sleep` are preferred if there's no need to disambiguate with a different speech engine like Dragon.