### PR TITLE
Update talon_user_file_sets.md to include Talon AI Tools

### DIFF
--- a/talon_user_file_sets.md
+++ b/talon_user_file_sets.md
@@ -50,6 +50,7 @@ Talon user sets that allow you to build voice commands more easily or define com
 ## Other
 
 * [AXKit](https://github.com/phillco/talon-axkit) (macOS only) to enhance Talon with native OS accessibility integrations
+* [Talon AI Tools](https://github.com/C-Loftus/talon-ai-tools): integrate the OpenAI API (ChatGPT) & GitHub Copilot to fix dictation errors or speed up your workflow
 * [knausj's clickless mouse](https://github.com/knausj85/clickless_mouse) Use the mouse for positioning, but hover an overlay to click.
 * [Subtitles.md](https://gist.github.com/tararoys/accf5506bea2c5c17e5bb31c7beac6e4)  A basic script for writing subtitles to a file for a screencapture.
 * [Talon Cheatsheet Generation Script](https://gist.github.com/tararoys/c538b7ae8e1f21db9a794c2c0f5becf4) How to generate a cheatsheet for your own repository


### PR DESCRIPTION
A fair amount of people have begun to use my AI tool repository for fixing dictation errors or using Copilot alongside Cursorless.  That latter feature was contributed to my repository by Pokey. As a result I think it is a good idea to include it here on the wiki.  I put it second in the list because it is second in the list in terms of popularity according to GitHub stars. 

 The repository link can be found here: https://github.com/C-Loftus/talon-ai-tools