### PR TITLE
Use most appropriate syntax highlighting ('config' for .talon files)

### DIFF
--- a/Running-Linux-or-Mac-Talon-Using-Windows-Dragon.md
+++ b/Running-Linux-or-Mac-Talon-Using-Windows-Dragon.md
@@ -13,7 +13,7 @@ Running Linux or Mac Talon against Windows Dragon:  This allows you to use a cop
 3. Right click on the Talon icon by the clock, go to Scripting, then “Open ~/talon”. Find draconity.toml in this directory and open it in a text editor.
 
 4. Add this text at the end of draconity.toml:
-```
+```python
 [[socket]]
 host = "0.0.0.0"
 port = 38065
@@ -22,7 +22,7 @@ port = 38065
 5. Copy the authentication key at the top of draconity.toml, you will need to have it to configure your other computer. Also note down the IP address of your Windows computer.
 
 6. Install Talon on your non-Windows computer, open draconity.toml in the same way, edit the authentication key to match the Windows computer, and add this text at the end:
-```
+```python
 [[remote]]
 host = "WINDOWS_IP_HERE"
 port = 38065

--- a/Running-Linux-or-Mac-Talon-Using-Windows-Dragon.md
+++ b/Running-Linux-or-Mac-Talon-Using-Windows-Dragon.md
@@ -13,7 +13,7 @@ Running Linux or Mac Talon against Windows Dragon:  This allows you to use a cop
 3. Right click on the Talon icon by the clock, go to Scripting, then “Open ~/talon”. Find draconity.toml in this directory and open it in a text editor.
 
 4. Add this text at the end of draconity.toml:
-```python
+```toml
 [[socket]]
 host = "0.0.0.0"
 port = 38065
@@ -22,7 +22,7 @@ port = 38065
 5. Copy the authentication key at the top of draconity.toml, you will need to have it to configure your other computer. Also note down the IP address of your Windows computer.
 
 6. Install Talon on your non-Windows computer, open draconity.toml in the same way, edit the authentication key to match the Windows computer, and add this text at the end:
-```python
+```toml
 [[remote]]
 host = "WINDOWS_IP_HERE"
 port = 38065

--- a/basic_customization.md
+++ b/basic_customization.md
@@ -43,14 +43,14 @@ Open up your editor and save an empty file called `simple_test.talon` somewhere 
 
 OK, let's get to defining the command. If you're running MacOS, copy/paste the following into your editor and save the file (ensure you have the spaces at the start of the 'key' line):
 
-```python
+```config
     select everything:
       key(cmd-a)
 ```
 
 If you're on Windows or Linux you can use this instead:
 
-```python
+```config
     select everything:
       key(ctrl-a)
 ```
@@ -124,7 +124,7 @@ OK, we're finished with this file now so you can delete it.
 
 Talon files look something like this:
 
-```python
+```config
     title: /Gmail/
     -
     find on page: key(ctrl-f)
@@ -185,7 +185,7 @@ As always, see the [unofficial docs](/unofficial_talon_docs) page for a much mor
 
 Often you will want to add a new voice command to press an application specific keyboard shortcut. Let's choose the YouTube webpage as our example. The following `.talon` file defines two new voice commands:
 
-```python
+```config
     title: /YouTube/
     -
     toggle play: key("space")
@@ -205,7 +205,7 @@ Keyboard shortcuts will almost always make use of the key() action. For more inf
 
 A reasonably common problem that comes up when using Talon with computer games is that the application only recognizes key presses intermittently or not at all. This can be because Talon presses and releases the keys too quickly. The following `.talon` file makes Talon hold down each key for 32 milliseconds before releasing it. You could try increasing the key\_hold value incrementally to find the smallest length of time you need to hold for the key to be recognized reliably:
 
-```python
+```config
     app.exe: my_game.exe
     -
     settings():
@@ -238,7 +238,7 @@ This also provides a simple way of overriding the behaviour of existing voice co
 
 The existing code is in a `.talon` file without a context header called `mouse.talon`:
 
-```python
+```config
     touch: 
         mouse_click(0)
         # close the mouse grid if open
@@ -252,7 +252,7 @@ We can see the `user.grid_close()` action is called to close the grid after clic
 
 If we wanted to stop the `user.grid_close()` behaviour we could just create a new `.talon` file and put in the following contents:
 
-```python
+```config
     os: mac
     -
     touch: 

--- a/basic_customization.md
+++ b/basic_customization.md
@@ -43,13 +43,17 @@ Open up your editor and save an empty file called `simple_test.talon` somewhere 
 
 OK, let's get to defining the command. If you're running MacOS, copy/paste the following into your editor and save the file (ensure you have the spaces at the start of the 'key' line):
 
+```python
     select everything:
       key(cmd-a)
+```
 
 If you're on Windows or Linux you can use this instead:
 
+```python
     select everything:
       key(ctrl-a)
+```
 
 You should see a line like `2021-09-02 17:33:36 DEBUG [+] /home/normal/.talon/user/mystuff/simple_test.talon` printed in your Talon log. This indicates that Talon has picked up your new/updated file and has loaded it. In general Talon will automatically pick up and apply any changes to `.talon` or `.py` files in your Talon user directory, so you don't have to restart Talon each time you make a change. If you don't see a line like that and can't figure it out, then you might want to ask for help on the [Talon slack](/) in the #help channel.
 
@@ -120,6 +124,7 @@ OK, we're finished with this file now so you can delete it.
 
 Talon files look something like this:
 
+```python
     title: /Gmail/
     -
     find on page: key(ctrl-f)
@@ -131,6 +136,7 @@ Talon files look something like this:
       key(ctrl-b)
       insert("type in this text (it will be bolded)")
       key(ctrl-b)
+```
 
 The part above the '-' line is called the "context header" and the part below is the "body". The context header decides under what circumstances the rest of the file will be active. The body defines voice commands and other behaviour.
 
@@ -156,7 +162,7 @@ You might have noticed that we've been using the key() and insert() actions in t
 2. Type `actions.list()` and press enter. This will list out all the available actions.
 3. You might like to look at this list of actions in your text editor (so you can search them, for example). To put the full list into your clipboard, copy and paste this code into the terminal window and press enter:
 
-```
+```python
 import io;old=sys.stdout;sys.stdout = io.StringIO();actions.list();clip.set_text(sys.stdout.getvalue());sys.stdout = old
 ```
 
@@ -179,6 +185,7 @@ As always, see the [unofficial docs](/unofficial_talon_docs) page for a much mor
 
 Often you will want to add a new voice command to press an application specific keyboard shortcut. Let's choose the YouTube webpage as our example. The following `.talon` file defines two new voice commands:
 
+```python
     title: /YouTube/
     -
     toggle play: key("space")
@@ -188,6 +195,7 @@ Often you will want to add a new voice command to press an application specific 
         sleep(100ms)
         insert("cats")
         key("enter")
+```
 
 These commands only apply when the window title has "YouTube" in it. "search cats" first presses the "/" key to focus the YouTube search box, then waits 100 milliseconds to make sure it has been focussed, then types in "cats" and presses enter.
 
@@ -197,10 +205,12 @@ Keyboard shortcuts will almost always make use of the key() action. For more inf
 
 A reasonably common problem that comes up when using Talon with computer games is that the application only recognizes key presses intermittently or not at all. This can be because Talon presses and releases the keys too quickly. The following `.talon` file makes Talon hold down each key for 32 milliseconds before releasing it. You could try increasing the key\_hold value incrementally to find the smallest length of time you need to hold for the key to be recognized reliably:
 
+```python
     app.exe: my_game.exe
     -
     settings():
         key_hold = 32
+```
 
 Note the use of app.exe as the context matcher to match the filename of the active program. See the [unofficial docs](/unofficial_talon_docs/#context-header) for a full list of available matchers.
 
@@ -228,25 +238,29 @@ This also provides a simple way of overriding the behaviour of existing voice co
 
 The existing code is in a `.talon` file without a context header called `mouse.talon`:
 
+```python
     touch: 
         mouse_click(0)
         # close the mouse grid if open
         user.grid_close()
-            # End any open drags
+        # End any open drags
         # Touch automatically ends left drags so this is for right drags specifically
         user.mouse_drag_end()
+```
 
 We can see the `user.grid_close()` action is called to close the grid after clicking the mouse. Also note the lines starting with '#' characters are called comments. They are just there for documentation and will not be otherwise processed by Talon.
 
 If we wanted to stop the `user.grid_close()` behaviour we could just create a new `.talon` file and put in the following contents:
 
+```python
     os: mac
     -
     touch: 
         mouse_click(0)
-            # End any open drags
+        # End any open drags
         # Touch automatically ends left drags so this is for right drags specifically
         user.mouse_drag_end()
+```
 
 Notice that we've given it a context header. Because this context headar is more specific (i.e. it has more rules in it) this implementation of "touch" will take precedence over the original. The implementation just has the `user.grid_close()` line and associated comment removed.
 
@@ -258,9 +272,11 @@ This is a simple way of overriding voice commands using `.talon` files. Many oth
 
 If you'd prefer not to you have Talon enabled when you start the app (and typically your computer), create a python filed in your user directory (e.g. `sleep.py`) and put in the following contents:
 
+```python
     from talon import app, actions
 
     def disable():
         actions.speech.disable()
 
     app.register("ready", disable)
+```

--- a/hardware.md
+++ b/hardware.md
@@ -74,7 +74,7 @@ The customization for foot pedals is more involved than editing Talon files, and
 * [Kinesis Savant Elite 2](https://kinesis-ergo.com/shop/savant-elite2-triple-pedal/) is mechanical and pedals can remap keys at the hardware level. It has 3 buttons.
 
 With the talon beta, the elegato foot pedal can be used as follows:
-```
+```python
 deck(pedal_left): print("left pedal")
 deck(pedal_middle): print("middle pedal")
 deck(pedal_right): print("right pedal")
@@ -85,7 +85,7 @@ deck(pedal_right): print("right pedal")
 With gamepad support in Talon you can recieve input from gamepads and/or joysticks. To check if your gamepad works with Talon, view the log after startup and look for a message after all the user scripts are read in. It should display something like `INFO Gamepad Attach: $CONTROLLER_ID ($CONTROLLER_NAME)` Gamepad input is particularly useful since it doesn't require you to use a hotkey (Pressing a different key from a Talon hotkey is often error prone, since the key is still held down while the other is pressed). Additionally, gamepads like the [Logitech Adaptive Gaming Kit and the Xbox Adaptive Controller](https://www.logitechg.com/en-us/products/gamepads/adaptive-gaming-kit-accessories) are useful ways to add physical buttons to your setup that don't require fine motor control. 
 
 Gamepad presses can be captured in .talon files similar to key presses
-```
+```python
 gamepad(dpad_up):           print("dpad_up")
 gamepad(dpad_down):         print("dpad_down")
 gamepad(east):              print("east/B")

--- a/hardware.md
+++ b/hardware.md
@@ -74,7 +74,7 @@ The customization for foot pedals is more involved than editing Talon files, and
 * [Kinesis Savant Elite 2](https://kinesis-ergo.com/shop/savant-elite2-triple-pedal/) is mechanical and pedals can remap keys at the hardware level. It has 3 buttons.
 
 With the talon beta, the elegato foot pedal can be used as follows:
-```python
+```config
 deck(pedal_left): print("left pedal")
 deck(pedal_middle): print("middle pedal")
 deck(pedal_right): print("right pedal")
@@ -85,7 +85,7 @@ deck(pedal_right): print("right pedal")
 With gamepad support in Talon you can recieve input from gamepads and/or joysticks. To check if your gamepad works with Talon, view the log after startup and look for a message after all the user scripts are read in. It should display something like `INFO Gamepad Attach: $CONTROLLER_ID ($CONTROLLER_NAME)` Gamepad input is particularly useful since it doesn't require you to use a hotkey (Pressing a different key from a Talon hotkey is often error prone, since the key is still held down while the other is pressed). Additionally, gamepads like the [Logitech Adaptive Gaming Kit and the Xbox Adaptive Controller](https://www.logitechg.com/en-us/products/gamepads/adaptive-gaming-kit-accessories) are useful ways to add physical buttons to your setup that don't require fine motor control. 
 
 Gamepad presses can be captured in .talon files similar to key presses
-```python
+```config
 gamepad(dpad_up):           print("dpad_up")
 gamepad(dpad_down):         print("dpad_down")
 gamepad(east):              print("east/B")

--- a/improving_recognition_accuracy.md
+++ b/improving_recognition_accuracy.md
@@ -49,7 +49,7 @@ Talon lets you configure how long it will wait after you stop speaking before tr
 * Speak faster, especially after consonants like "p" that involve stopping airflow. In utterances like "stop it", there is a natural pause between "stop" and "it".  Some people have just slightly longer stops than others, but can avoid it when preparing to talk fluently.
 
 * Increase Talon's wait time. This has the disadvantage of making all commands react slower, but it _can_ eliminate the cutoffs. Do this by adding a `settings.talon` file to your user directory with the following content:
-  ```
+  ```python
   settings():
       # minimum silence time (in seconds) before speech is cut off, default 0.3
       speech.timeout = 0.4

--- a/improving_recognition_accuracy.md
+++ b/improving_recognition_accuracy.md
@@ -49,7 +49,7 @@ Talon lets you configure how long it will wait after you stop speaking before tr
 * Speak faster, especially after consonants like "p" that involve stopping airflow. In utterances like "stop it", there is a natural pause between "stop" and "it".  Some people have just slightly longer stops than others, but can avoid it when preparing to talk fluently.
 
 * Increase Talon's wait time. This has the disadvantage of making all commands react slower, but it _can_ eliminate the cutoffs. Do this by adding a `settings.talon` file to your user directory with the following content:
-  ```python
+  ```config
   settings():
       # minimum silence time (in seconds) before speech is cut off, default 0.3
       speech.timeout = 0.4

--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -24,7 +24,7 @@ The primary way to extend talon is using `.talon` files placed in the `user` dir
 
 An example `.talon` file might look like this:
 
-```
+```python
 # Comments start with a # sign, and they must always be on their own line.
 #
 # This part, the context header, defines under which circumstances this file applies.
@@ -102,27 +102,27 @@ We've already indicated what requirements and scopes are, so lets move on to the
 
 The next thing to talk about is what happens when we have multiple lines in the context header. Talon lets you combine these together as a composite matcher following specific rules. In the following examples the comment contains an expression describing what the rule will match, e.g. `paint_app or (windows and not notepad_app)`. In this case the expression would match the when the app `paint_app` is active or the operating system is `windows` and the app `notepad_app` is not active.
 
-```
+```python
 # paint_app or notepad_app
 app: paint_app
 app: notepad_app
 ```
 
-```
+```python
 # (paint_app or notepad_app) and windows
 app: paint_app
 os: windows
 app: notepad_app
 ```
 
-```
+```python
 # (paint_app and windows) or notepad_app
 app: paint_app
 and os: windows
 app: notepad_app
 ```
 
-```
+```python
 # paint_app and not windows
 app: paint_app
 not os: windows
@@ -134,7 +134,7 @@ So without modifiers, requirements of the same type (e.g. two apps) are OR-ed to
 
 A voice command has the format `RULE: BODY`, where `RULE` determines what words activate the command, and `BODY` defines what the command does when activated:
 
-```
+```python
 # -------- RULE ----------------  ------ BODY -------
 ([channel] unread next | goneck): key(alt-shift-down)
 ```
@@ -168,8 +168,7 @@ In general you shouldn't anchor rules since it prevents the user from chaining t
 
 The BODY part of a command is implemented in Talonscript, a simple statically typed language. We'll discuss Talonscript and how it interracts with the RULE part of the command with reference to the following `.talon` file:
 
-```
--
+```python
 # The following captures are implemented in the [Talon Community](https://github.com/talonhub/community) user file set:
 #
 # <user.letter> is a list mapping words like 'plex' or 'gust' to latin letters like 'x' or 'g'
@@ -218,7 +217,7 @@ In the above we can see that the lists and captures in the rule part are bound t
 
 In terms of the Talonscript itself, the syntax can be thought of as a very limited subset of Python. Consider the following file which (as of writing) demonstrates all available syntax. See the inline comments for what everything does:
 
-```
+```python
 # Comments must be on their own line (optionally preceeded by whitespace)
 some [<user.letter>] command:
     # or operator is used to deal with optional or alternative command parts. It works as the null
@@ -276,7 +275,7 @@ some [<user.letter>] command:
 
 The most common usage after voice commands is to adjust [settings](/unofficial_talon_docs#settings). The following changes the given setting values when the context header matches:
 
-```
+```python
 title: /my app/
 -
 settings():
@@ -287,7 +286,7 @@ settings():
 
 You can also activate [tags](/unofficial_talon_docs#tags). This snippet activates the `user.my_tag` tag when the context header matches. This is used reasonably often to enable extra sets of voice commands for the given context.
 
-```
+```python
 title: /my app/
 -
 tag(): user.my_tag
@@ -295,7 +294,7 @@ tag(): user.my_tag
 
 Another feature is the ability to bind keyboard shortcuts.
 
-```
+```python
 title: /my app/
 -
 # Show notification saying the key was pressed and prevent other apps from receiving the key event
@@ -330,7 +329,7 @@ The final concept is the Module. This is used to register particular instances o
 
 A Module is a place for giving things names. In particular, it can declare [actions](/unofficial_talon_docs#actions), [lists](/unofficial_talon_docs#lists), [captures](/unofficial_talon_docs#captures), [scopes](/unofficial_talon_docs#scopes), [tags](/unofficial_talon_docs#tags), [modes](/unofficial_talon_docs#modes), [settings](/unofficial_talon_docs#settings) and well-known [applications](/unofficial_talon_docs#apps). In Python, you can construct a module like so:
 
-```
+```python
 from talon import Module
 mod = Module()
 ```
@@ -378,7 +377,7 @@ See examples in the [Actions](#actions), [Lists](#lists), [Captures](#captures),
 
 An action is a specially registered Python function that can be called by Talon voice commands. The code in `.talon` files ends up using built in or user defined actions for all its behavior. Consider this example:
 
-```talon
+```python
 my command:
     text = "hello"
     mangled_text = user.mangle(text)
@@ -475,7 +474,7 @@ ctx_java.lists["user.exception_class"] = {
 This sets up a list which matches a list of standard exceptions for the target programming language. Note that we can have a different set of item keys in the list for different contexts. Note also that our list (like user defined actions) is prefixed with `user.` to identify it as custom code.
 
 **`exceptions.talon`:**
-```
+```python
 exception {user.exception_class}: insert(user.exception_class)
 ```
 
@@ -551,7 +550,7 @@ class GameActions:
 This code first implements a new capture which matches on any of the compass directions, parses that and returns a data structure describing which directions were indicated. There is also a set of actions included which take this data structure and use it to press the appropriate keys.
 
 **`game_one.talon`**:
-```
+```python
 move <user.dpad_input>: user.dpad_move(user.dpad_input)
 attack <user.dpad_input>: user.dpad_attack(user.dpad_input)
 ```
@@ -626,7 +625,7 @@ mod.tag("tabs", desc="basic commands for working with tabs within a window are a
 Next let's define a set of generic voice commands we think will apply to all applications with tabs:
 
 **`tabs.talon`:**
-```
+```python
 # This selects for the tag 'user.tabs'.
 tag: user.tabs
 -
@@ -640,7 +639,7 @@ reopen tab: app.tab_reopen()
 Finally, let's activate these voice commands for the firefox application:
 
 **`firefox.talon`:**
-```
+```python
 app: Firefox
 -
 # This activates the tag 'user.tabs'.
@@ -698,7 +697,7 @@ ctx.apps = ['fancyedit']
 ```
 
 Use the well-known app - **`fancyedit.talon`:**
-```
+```python
 app: fancyedit
 -
 my fancy editor command: key(ctrl-alt-shift-y)
@@ -711,14 +710,14 @@ Modes are property you can match in your `.talon` file context header. They are 
 
 The built in 'command' mode is special in that it is an implicit requirement in all `.talon` files that haven't explicitly specified a mode. So this `.talon` file would be active in command mode:
 
-```
+```python
 -
 insert test: "command mode active"
 ```
 
 Whereas this one would only be active in dictation mode:
 
-```
+```python
 mode: dictation
 -
 insert mode: "dictation mode active"
@@ -739,13 +738,13 @@ mod.mode("single_application", desc="Non-multitasking mode (e.g. computer games)
 
 Then you might make a couple of generic 'mode entry' and 'mode exit' commands:
 
-```
+```python
 ^single application mode$:
     mode.enable("user.single_application")
     mode.disable("command")
 ```
 
-```
+```python
 mode: user.single_application
 -
 ^command mode$:
@@ -757,7 +756,7 @@ Note that I've shadowed the existing `command mode` command from [Talon Communit
 
 After that we could define a set of commands which would be available in our game:
 
-```
+```python
 mode: user.single_application
 title: /My Game/
 -
@@ -788,7 +787,7 @@ cron.interval("1m", my_scope_updater.update)
 ```
 
 `test.talon`
-```
+```python
 # This matcher can either be a plain string or a regex
 user.current_time: /AM$/
 -
@@ -806,7 +805,7 @@ Settings allow you to control some of the parameters of your python files by cha
 Settings are defined on Modules. Each setting has a name, type, default value, and description. The following example shows how to define a setting in python and get its contextually dependent value.
 
 `setting.py`
-```
+```python
 from talon import Module, settings
 
 mod = Module()
@@ -827,7 +826,7 @@ Note that the name of the setting (the first argument to mod.setting) in the exa
 The following example shows how you would change the value for that setting in a .talon file. Any number of settings can be defined in a single settings block, but any invalid syntax will prevent the entire block from applying.
 
 `setting.talon`
-```
+```python
 -
 settings():
     user.my_user_file_set_horizontal_position = 50
@@ -837,7 +836,7 @@ settings():
 You can also set the value of a setting from Python:
 
 `myfile.py`
-```
+```python
 from talon import Context
 
 ctx = Context()
@@ -848,7 +847,7 @@ ctx.settings["user.my_user_file_set_horizontal_position"] = 50
 It is also possible to register a callback function to be called whenever a setting changes. This is done by calling settings.register() with a setting name and a function to call. If the name string is blank (like in the example below) then the callback function will be called whenever any setting is changed. When the name is not blank the function will only be called when a setting with a matching name is changed.
 
 `listener.py`
-```
+```python
 def settings_change_handler(*args):
     print("A setting has changed")
 
@@ -904,7 +903,7 @@ An escape hatch for this kind of thing is the `.venv` folder in your Talon home 
 
 In a `.talon` file, a `settings()` block can be used to alter settings, both for Talon and for user modules. For example:
 
-```
+```python
 app: Emacs
 -
 settings():
@@ -943,7 +942,7 @@ A `.talon-list` doesn't require a `:` if the key is the same as the value. The r
 
 The following example shows a `.talon-list` file that defines a few special characters. Note how the string doesn't need to be wrapped in quotations and can either be just itself or a mapping to a different string.
 
-```
+```python
 list: user.key_special
 -
 enter
@@ -955,7 +954,7 @@ page down:                  pagedown
 
 We then need to initialize the list within a Talon module object. This is important for giving the list an associated comment.  This is done within a Python file in our user directory.  As one can see, it is a similar process to declaring a normal context list except for the fact that all the context matching is now done within the  `.talon-list` file and we no longer need to do our context matching within Python.
 
-```
+```python
 from talon import Module
 
 mod = Module()
@@ -965,6 +964,6 @@ mod.list("key_special", "The list of special keys we can input through voice com
 
 We could then use this list in a `.talon` file like so:
 
-```
+```python
 {user.key_special}:              key(symbol)
 ```

--- a/unofficial_talon_docs.md
+++ b/unofficial_talon_docs.md
@@ -24,7 +24,7 @@ The primary way to extend talon is using `.talon` files placed in the `user` dir
 
 An example `.talon` file might look like this:
 
-```python
+```config
 # Comments start with a # sign, and they must always be on their own line.
 #
 # This part, the context header, defines under which circumstances this file applies.
@@ -102,27 +102,27 @@ We've already indicated what requirements and scopes are, so lets move on to the
 
 The next thing to talk about is what happens when we have multiple lines in the context header. Talon lets you combine these together as a composite matcher following specific rules. In the following examples the comment contains an expression describing what the rule will match, e.g. `paint_app or (windows and not notepad_app)`. In this case the expression would match the when the app `paint_app` is active or the operating system is `windows` and the app `notepad_app` is not active.
 
-```python
+```config
 # paint_app or notepad_app
 app: paint_app
 app: notepad_app
 ```
 
-```python
+```config
 # (paint_app or notepad_app) and windows
 app: paint_app
 os: windows
 app: notepad_app
 ```
 
-```python
+```config
 # (paint_app and windows) or notepad_app
 app: paint_app
 and os: windows
 app: notepad_app
 ```
 
-```python
+```config
 # paint_app and not windows
 app: paint_app
 not os: windows
@@ -134,7 +134,7 @@ So without modifiers, requirements of the same type (e.g. two apps) are OR-ed to
 
 A voice command has the format `RULE: BODY`, where `RULE` determines what words activate the command, and `BODY` defines what the command does when activated:
 
-```python
+```config
 # -------- RULE ----------------  ------ BODY -------
 ([channel] unread next | goneck): key(alt-shift-down)
 ```
@@ -168,7 +168,7 @@ In general you shouldn't anchor rules since it prevents the user from chaining t
 
 The BODY part of a command is implemented in Talonscript, a simple statically typed language. We'll discuss Talonscript and how it interracts with the RULE part of the command with reference to the following `.talon` file:
 
-```python
+```config
 # The following captures are implemented in the [Talon Community](https://github.com/talonhub/community) user file set:
 #
 # <user.letter> is a list mapping words like 'plex' or 'gust' to latin letters like 'x' or 'g'
@@ -217,7 +217,7 @@ In the above we can see that the lists and captures in the rule part are bound t
 
 In terms of the Talonscript itself, the syntax can be thought of as a very limited subset of Python. Consider the following file which (as of writing) demonstrates all available syntax. See the inline comments for what everything does:
 
-```python
+```config
 # Comments must be on their own line (optionally preceeded by whitespace)
 some [<user.letter>] command:
     # or operator is used to deal with optional or alternative command parts. It works as the null
@@ -275,7 +275,7 @@ some [<user.letter>] command:
 
 The most common usage after voice commands is to adjust [settings](/unofficial_talon_docs#settings). The following changes the given setting values when the context header matches:
 
-```python
+```config
 title: /my app/
 -
 settings():
@@ -286,7 +286,7 @@ settings():
 
 You can also activate [tags](/unofficial_talon_docs#tags). This snippet activates the `user.my_tag` tag when the context header matches. This is used reasonably often to enable extra sets of voice commands for the given context.
 
-```python
+```config
 title: /my app/
 -
 tag(): user.my_tag
@@ -294,7 +294,7 @@ tag(): user.my_tag
 
 Another feature is the ability to bind keyboard shortcuts.
 
-```python
+```config
 title: /my app/
 -
 # Show notification saying the key was pressed and prevent other apps from receiving the key event
@@ -377,7 +377,7 @@ See examples in the [Actions](#actions), [Lists](#lists), [Captures](#captures),
 
 An action is a specially registered Python function that can be called by Talon voice commands. The code in `.talon` files ends up using built in or user defined actions for all its behavior. Consider this example:
 
-```python
+```config
 my command:
     text = "hello"
     mangled_text = user.mangle(text)
@@ -474,7 +474,7 @@ ctx_java.lists["user.exception_class"] = {
 This sets up a list which matches a list of standard exceptions for the target programming language. Note that we can have a different set of item keys in the list for different contexts. Note also that our list (like user defined actions) is prefixed with `user.` to identify it as custom code.
 
 **`exceptions.talon`:**
-```python
+```config
 exception {user.exception_class}: insert(user.exception_class)
 ```
 
@@ -550,7 +550,7 @@ class GameActions:
 This code first implements a new capture which matches on any of the compass directions, parses that and returns a data structure describing which directions were indicated. There is also a set of actions included which take this data structure and use it to press the appropriate keys.
 
 **`game_one.talon`**:
-```python
+```config
 move <user.dpad_input>: user.dpad_move(user.dpad_input)
 attack <user.dpad_input>: user.dpad_attack(user.dpad_input)
 ```
@@ -625,7 +625,7 @@ mod.tag("tabs", desc="basic commands for working with tabs within a window are a
 Next let's define a set of generic voice commands we think will apply to all applications with tabs:
 
 **`tabs.talon`:**
-```python
+```config
 # This selects for the tag 'user.tabs'.
 tag: user.tabs
 -
@@ -639,7 +639,7 @@ reopen tab: app.tab_reopen()
 Finally, let's activate these voice commands for the firefox application:
 
 **`firefox.talon`:**
-```python
+```config
 app: Firefox
 -
 # This activates the tag 'user.tabs'.
@@ -697,7 +697,7 @@ ctx.apps = ['fancyedit']
 ```
 
 Use the well-known app - **`fancyedit.talon`:**
-```python
+```config
 app: fancyedit
 -
 my fancy editor command: key(ctrl-alt-shift-y)
@@ -710,14 +710,14 @@ Modes are property you can match in your `.talon` file context header. They are 
 
 The built in 'command' mode is special in that it is an implicit requirement in all `.talon` files that haven't explicitly specified a mode. So this `.talon` file would be active in command mode:
 
-```python
+```config
 -
 insert test: "command mode active"
 ```
 
 Whereas this one would only be active in dictation mode:
 
-```python
+```config
 mode: dictation
 -
 insert mode: "dictation mode active"
@@ -738,13 +738,13 @@ mod.mode("single_application", desc="Non-multitasking mode (e.g. computer games)
 
 Then you might make a couple of generic 'mode entry' and 'mode exit' commands:
 
-```python
+```config
 ^single application mode$:
     mode.enable("user.single_application")
     mode.disable("command")
 ```
 
-```python
+```config
 mode: user.single_application
 -
 ^command mode$:
@@ -756,7 +756,7 @@ Note that I've shadowed the existing `command mode` command from [Talon Communit
 
 After that we could define a set of commands which would be available in our game:
 
-```python
+```config
 mode: user.single_application
 title: /My Game/
 -
@@ -787,7 +787,7 @@ cron.interval("1m", my_scope_updater.update)
 ```
 
 `test.talon`
-```python
+```config
 # This matcher can either be a plain string or a regex
 user.current_time: /AM$/
 -
@@ -826,7 +826,7 @@ Note that the name of the setting (the first argument to mod.setting) in the exa
 The following example shows how you would change the value for that setting in a .talon file. Any number of settings can be defined in a single settings block, but any invalid syntax will prevent the entire block from applying.
 
 `setting.talon`
-```python
+```config
 -
 settings():
     user.my_user_file_set_horizontal_position = 50
@@ -903,7 +903,7 @@ An escape hatch for this kind of thing is the `.venv` folder in your Talon home 
 
 In a `.talon` file, a `settings()` block can be used to alter settings, both for Talon and for user modules. For example:
 
-```python
+```config
 app: Emacs
 -
 settings():
@@ -942,7 +942,7 @@ A `.talon-list` doesn't require a `:` if the key is the same as the value. The r
 
 The following example shows a `.talon-list` file that defines a few special characters. Note how the string doesn't need to be wrapped in quotations and can either be just itself or a mapping to a different string.
 
-```python
+```config
 list: user.key_special
 -
 enter
@@ -964,6 +964,6 @@ mod.list("key_special", "The list of special keys we can input through voice com
 
 We could then use this list in a `.talon` file like so:
 
-```python
+```config
 {user.key_special}:              key(symbol)
 ```


### PR DESCRIPTION
Ideally we would incorporate syntax highlighting for talon files (e.g., figure out how to pull in https://github.com/mrob95/vscode-TalonScript/tree/master). Until that happens, we can use the `config` syntax highlighting. This change specifies `config` as the syntax highlighter for `.talon` files, as well as fixes a few that should be `python` or `toml`.