### PR TITLE
Remove chess grid from talon user file sets 

### DIFF
--- a/talon_user_file_sets.md
+++ b/talon_user_file_sets.md
@@ -32,7 +32,6 @@ The easiest way to control your mouse with Talon is to use an eye tracker. But t
 
 ## Application specific
 
-* [Chess board integration](https://github.com/brollin/chess_grid/) Integration with computer based chess. Lets you play chess on Lichess.org for example.
 * [Rango](https://github.com/david-tejada/rango) Allows you to easily click active elements in the browser using your voice. An alternative to Vimium with better Talon integration.
 
 ## Command builders and macros


### PR DESCRIPTION
[Chess grid]() doesn't work with the latest version of Talon and I don't have plans to update it in the near term so I think it's best to remove it from this list. Lichess has both a keyboard input that works great with talon, as well as their own voice move feature, so this tool feels unnecessary at the moment. 