### PR TITLE
Make header not sticky

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,8 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+/* Disable sticky header */
+.navbar--fixed-top {
+  position: initial;
+}


### PR DESCRIPTION
This makes the site header not sticky. [Sticky headers are an annoyance for people who scroll one screenful at a time](https://alisdair.mcdiarmid.org/kill-sticky-headers/):

> I also normally scroll down using the space key, which scrolls just less than one full viewport at a time. When you cover up part of your content with a sticky element, that means that the space key scrolls too far down. Then I lose my position and have to scroll back up.

If there's no sticky header, I just need to say  `space` to continue reading.

If there's a sticky header, then I have to say `space`, lose the place on the page where I was reading, then say `go up twice`, then continue reading. _Every single time I'm scrolling down one page_.

If I happen to want something in the header — **which isn't often** compared to how often I scroll down reading a page — I can press the Home key or say `home` or `scroll to top`, depending on whether I'm using Talon, Windows Speech Recognition, or Voice Control.