### PR TITLE
Fixed typo on main page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -12,14 +12,14 @@ The goal of this wiki is to provide information and documentation for the users 
 
 ## Wiki Navigation
 
-| If you are looking for:                           | See:                                                                 |
-| ------------------------------------------------- | -------------------------------------------------------------------- |
-| Information on getting started with Talon         | [Getting Started](/Quickstart/getting_started)                       |
-| How to customize Talon                 | [Basic Customization](/Customization/basic_customization) |
-| Troubleshooting help                              | [Troubleshooting](/Quickstart/troubleshooting)                       |
-| Help with deciding on a microphone or eye tracker | [Hardware](/Quickstart/Hardware)                                     |
-| Videos of Talon in use                            | [Video Demos](/Integrations/talon_related_resources)                 |
-| Answers to frequently asked questions             | [FAQ](/Quickstart/FAQ)                                               |
+| If you are looking for:                           | See:                                                      |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| Information on getting started with Talon         | [Getting Started](/Quickstart/getting_started)            |
+| How to customize Talon                            | [Basic Customization](/Customization/basic_customization) |
+| Troubleshooting help                              | [Troubleshooting](/Quickstart/troubleshooting)            |
+| Help with deciding on a microphone or eye tracker | [Hardware](/Quickstart/Hardware)                          |
+| Videos of Talon in use                            | [Video Demos](/Integrations/talon_related_resources)      |
+| Answers to frequently asked questions             | [FAQ](/Quickstart/FAQ)                                    |
 
 ## Talon Slack
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,7 +15,7 @@ The goal of this wiki is to provide information and documentation for the users 
 | If you are looking for:                           | See:                                                                 |
 | ------------------------------------------------- | -------------------------------------------------------------------- |
 | Information on getting started with Talon         | [Getting Started](/Quickstart/getting_started)                       |
-| Documentation of Talon's features                 | [Unofficial Talon Documentation](/Customization/basic_customization) |
+| Documentation of Talon's features                 | [Basic Customization](/Customization/basic_customization) |
 | Troubleshooting help                              | [Troubleshooting](/Quickstart/troubleshooting)                       |
 | Help with deciding on a microphone or eye tracker | [Hardware](/Quickstart/Hardware)                                     |
 | Videos of Talon in use                            | [Video Demos](/Integrations/talon_related_resources)                 |

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,7 +15,7 @@ The goal of this wiki is to provide information and documentation for the users 
 | If you are looking for:                           | See:                                                                 |
 | ------------------------------------------------- | -------------------------------------------------------------------- |
 | Information on getting started with Talon         | [Getting Started](/Quickstart/getting_started)                       |
-| Documentation of Talon's features                 | [Basic Customization](/Customization/basic_customization) |
+| How to customize Talon                 | [Basic Customization](/Customization/basic_customization) |
 | Troubleshooting help                              | [Troubleshooting](/Quickstart/troubleshooting)                       |
 | Help with deciding on a microphone or eye tracker | [Hardware](/Quickstart/Hardware)                                     |
 | Videos of Talon in use                            | [Video Demos](/Integrations/talon_related_resources)                 |


### PR DESCRIPTION
Changed this to refer to basic customization instead of the unofficial talon docs. I think that is too specific to call out on the main landing page. Eventually this main page may just be entirely refactored but just made it consistent for the time being.

Leaving open until Emily approves.