### PR TITLE
Enhance the "Unofficial Docs" landing page

### DIFF
--- a/src/pages/unofficial_talon_docs.md
+++ b/src/pages/unofficial_talon_docs.md
@@ -2,8 +2,8 @@
 sidebar_class_name: hidden
 ---
 
-# This page has been refactored!
+# This page has moved!
 
-All Talon API documentation and scripting has now been move into categories in the [Customization](/Customization/basic_customization) tab!
+All Talon API documentation and scripting resources have moved into categories in the [Customization](/Customization/basic_customization) tab. Temporarily, the old page will still be accessible via https://old.talon.wiki/unofficial_talon_docs/.
 
-Please [file an issue](https://github.com/TalonCommunity/Wiki/issues) if you think something has gone missing
+Please [file an issue](https://github.com/TalonCommunity/Wiki/issues) or let us know in the #talon_docs channel of the [Talon Slack](https://talonvoice.com/chat) if you encounter any issues.


### PR DESCRIPTION
This page exists to redirect folks who may be trying to access the old Unofficial Docs page, which was by far the most used resource of the wiki. This change makes a few enhancements to improve the experience of landing on this page.

Included:

* A few nit updates to langauge
* A link to the old page which will still be accessible temporarily
* Mentions the talon_docs channel as an alternative source for reporting issues.