### PR TITLE
Update settings.md

### DIFF
--- a/docs/Customization/Talon Framework/settings.md
+++ b/docs/Customization/Talon Framework/settings.md
@@ -90,4 +90,4 @@ The following three settings, `insert_wait`, `key_hold`, and `key_wait`, can be 
 `speech.timeout`
 : This determines how long a pause Talon waits for before deciding you've finished speaking and interpreting what you've just said as a sequence of commands. This parameter is generally very important; for example, it determines the the amount of time you can pause between saying 'phrase' and the following phrase.
 
-It is measured in seconds; the default is 0.150, i.e. 150 milliseconds. It has been mentioned in #beta that this setting may not always be available as it was offered as a quick fix in Talon 1283 for Talon 1274 cutting input off too soon sometimes.
+It is measured in seconds; the default is 0.300, i.e. 300 milliseconds. It has been mentioned in #beta that this setting may not always be available as it was offered as a quick fix in Talon 1283 for Talon 1274 cutting input off too soon sometimes.


### PR DESCRIPTION
The default speech.timeout is 300 and has been for a while (I think since 0.4?).