### PR TITLE
Update lists.md

### DIFF
--- a/docs/Customization/Talon Framework/lists.md
+++ b/docs/Customization/Talon Framework/lists.md
@@ -41,7 +41,7 @@ This sets up a list which matches a list of standard exceptions for the target p
 **`exceptions.talon`:**
 
 ```talon
-exception {user.exception_class}: insert(user.exception_class)
+exception {user.exception_class}: insert(exception_class)
 ```
 
 We make use of our list in the above .talon file by referring to it with the curly brace syntax.


### PR DESCRIPTION
When using lists, you don't prefix them with `user.` on the right-hand-side of the rule, only the left.