### PR TITLE
Screenshot of beta channel icon and canvas icon

### DIFF
--- a/docs/Quickstart/beta_talon.md
+++ b/docs/Quickstart/beta_talon.md
@@ -10,4 +10,9 @@ The beta version of Talon is available for Windows, Mac, and Linux, and provides
 - Higher priority support
 - Access to additional speech engine options
 
-Installing the beta version requires [Patreon support](https://www.patreon.com/join/lunixbochs). After becoming a [beta tier Patreon](https://www.patreon.com/join/lunixbochs), join the [Talon Voice Slack](https://talonvoice.com/chat) and request access to the `#beta` channel from `@aegis`, the developer of Talon. Download links to complete the installation can be found in the #beta channel's pinned messages.
+Installing the beta version requires [Patreon support](https://www.patreon.com/join/lunixbochs). After becoming a [beta tier Patreon](https://www.patreon.com/join/lunixbochs), join the [Talon Voice Slack](https://talonvoice.com/chat) and request access to the `#beta` channel from `@aegis`, the developer of Talon.
+
+Download links to complete the installation can be found in the `#beta` channel's Canvas, or its pinned messages.
+
+![Screenshot of the Slack application showing the padlock icon for the beta channel](https://github.com/TalonCommunity/Wiki/assets/25167/de7d5ddd-0aaa-404d-9d7a-72caecadd913)
+![Screenshot of the Slack application showing the icon for the Canvas feature](https://github.com/TalonCommunity/Wiki/assets/25167/af3a6388-4ad3-463c-9555-f3fca92c30cf)


### PR DESCRIPTION
Show users what the beta channel looks like so they don't confuse a regular channel with it.

Also mention the "canvas" first, instead of the pinned messages, since it's also got more interesting information in it.

- [ ] Do I have to move the images to the git repo itself for this to work? I just copypasted the images out of my screenshot tool into the editor and it uploaded them to wiki/assets, which is extremely convenient compared to having to touch my filesystem, but the image files should probably become versioned? also maybe optipng it as well, or webp