### PR TITLE
fix typo on getting started page

### DIFF
--- a/docs/Quickstart/getting_started.md
+++ b/docs/Quickstart/getting_started.md
@@ -59,7 +59,7 @@ If at any point you need help with your Talon setup, join the [Talon Voice Slack
 
 Once the basics somewhat work for you, you'll likely want to improve your experience using Talon:
 
-- For users who want earlier access to new features, priority support, and access to additional [speech engines](Speech Engines/speech engines.md), install the [beta version](beta_talon.md).
+- For users who want earlier access to new features, priority support, and access to additional [speech engines](./Speech%20Engines/speech%20engines.md), install the [beta version](beta_talon.md).
 - [Improve Recognition Accuracy](improving_recognition_accuracy): Better accuracy never hurts. Many people have to tweak something.
 - [Customize Talon](../Customization/basic_customization.md): learn about how to configure Talon to your liking.
 - [Talon-Related Resources](../Integrations/talon_related_resources): a varied list of resources for Talon uses.


### PR DESCRIPTION
fixes a typo in a markdown link