### PR TITLE
Add note about non-explicit app: matching

### DIFF
--- a/docs/Customization/Talon Framework/apps.md
+++ b/docs/Customization/Talon Framework/apps.md
@@ -39,3 +39,12 @@ app: fancyedit
 -
 my fancy editor command: key(ctrl-alt-shift-y)
 ```
+
+## Non-Explicit App Header Matching
+
+Explicitly defining an `app` match to a well-known name, as described above, is the prefered approach. With that said,
+it's worth noting that talon will match against `app: ...` even if something hasn't already been explicitly declared.
+Using the the Gnome `clocks` GUI application on Linux as an example, where no existing explicit `app` declared,  talon
+debug window will show `app.app = org.gnome.clocks`. In this case, `app.app` matches what talon has in `app.name`. As
+such, you can add `app: org.gnome.clocks` in your talon file context header and it will match. This type of non-explicit
+matching should be avoided when contributing code to the community repo.

--- a/docs/Customization/Talon Framework/apps.md
+++ b/docs/Customization/Talon Framework/apps.md
@@ -44,7 +44,7 @@ my fancy editor command: key(ctrl-alt-shift-y)
 
 Explicitly defining an `app` match to a well-known name, as described above, is the prefered approach. With that said,
 it's worth noting that talon will match against `app: ...` even if something hasn't already been explicitly declared.
-Using the the Gnome `clocks` GUI application on Linux as an example, where no existing explicit `app` declared,  talon
+Using the the Gnome `clocks` GUI application on Linux as an example, where no existing explicit `app` declared, talon
 debug window will show `app.app = org.gnome.clocks`. In this case, `app.app` matches what talon has in `app.name`. As
 such, you can add `app: org.gnome.clocks` in your talon file context header and it will match. This type of non-explicit
 matching should be avoided when contributing code to the community repo.


### PR DESCRIPTION
This adds a note about non-explicit `app:` context header matching, which came out of me being confused while helping with PR1401 on community (see comment https://github.com/talonhub/community/pull/1401#pullrequestreview-2095812434 and onwards).