### PR TITLE
Stop recommending old sleep commands

### DIFF
--- a/docs/Basic Usage/basic_usage.md
+++ b/docs/Basic Usage/basic_usage.md
@@ -15,9 +15,7 @@ To keep track of what mode you are in with a visual icon, enable the [mode indic
 | Command          | Description                 |
 | ---------------- | --------------------------- |
 | `wake up`        | Enable speech recognition.  |
-| `talon wake`     | Enable speech recognition.  |
 | `go to sleep`    | Disable speech recognition. |
-| `talon sleep`    | Disable speech recognition. |
 | `dictation mode` | Switch to dictation mode.   |
 | `command mode`   | Switch to command mode.     |
 


### PR DESCRIPTION
Aegis has asked us to stop recommending people use `talon sleep` and `talon wake` with conformer because those commands were added for dealing with dragon because we could not override its `wake up` and `go to sleep` commands. 