### PR TITLE
fix old single word media commands

### DIFF
--- a/docs/Basic Usage/basic_usage.md
+++ b/docs/Basic Usage/basic_usage.md
@@ -81,10 +81,10 @@ These commands will open up a CSV or [Talon list](Customization/talon_lists.md) 
 
 | Command         |
 | --------------- |
-| `mute`          |
+| `media mute`          |
 | `play next`     |
 | `play previous` |
-| `play`          |
+| `media play`          |
 
 ## Controlling the Tobii eye tracker
 

--- a/docs/Basic Usage/basic_usage.md
+++ b/docs/Basic Usage/basic_usage.md
@@ -81,10 +81,10 @@ These commands will open up a CSV or [Talon list](Customization/talon_lists.md) 
 
 | Command         |
 | --------------- |
-| `media mute`          |
+| `media mute`    |
 | `play next`     |
 | `play previous` |
-| `media play`          |
+| `media play`    |
 
 ## Controlling the Tobii eye tracker
 


### PR DESCRIPTION
`basic_usage.md` includes single word media commands "mute" and "play" which were both [removed from community](https://github.com/talonhub/community/commit/b7f17a8dcbaeba6418493b054e6f246e7803e5c0). Both [now](https://github.com/talonhub/community/blob/a007ee7cfe9b18e033fdcec12946a4dbc76a1f7d/plugin/media/media.talon) have two options:

- `(volume | media) mute`
- `media (play | pause)`

I opted to only list one of the options for each, given that none of the other examples on the page contain the A OR B syntax.

I'm not sure if I've created this pull request correctly. It's my first time.