### PR TITLE
fixed contributing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This is the source repo for the [Talon wiki](https://talon.wiki), a community maintained wiki for [Talon voice](https://talonvoice.com/). For information on how to contribute, see our [Contributing](https://talon.wiki/CONTRIBUTING/) documentation.
+This is the source repo for the [Talon wiki](https://talon.wiki), a community maintained wiki for [Talon voice](https://talonvoice.com/). For information on how to contribute, see our [Contributing](https://github.com/TalonCommunity/Wiki/blob/main/CONTRIBUTING.md) documentation.


### PR DESCRIPTION
The Link in the repositories read me leads me to https://talon.wiki/CONTRIBUTING/ , which only gives me a 502 Bad Gateway. I assume https://github.com/TalonCommunity/Wiki/blob/main/CONTRIBUTING.md is the actual location, so I exchanged the link