### PR TITLE
Use internal community names for things

### DIFF
--- a/docs/Voice Coding/language-specific.md
+++ b/docs/Voice Coding/language-specific.md
@@ -18,7 +18,7 @@ This activates the commands `state self` for inserting the language equivalent o
 
 ## user.code_functions_common
 
-This activates support for quickly calling commonly used functions in the active language. `toggle funk` toggles showing the available common functions with associated numbers. `funk (function name)` will insert the specified function call. `funk wrap (function name)` wraps the currently selected text inside the function call. While the available common functions are being displayed, `funk cell (function number)` and `funk wrap (function number)` can be used for calling a function or wrapping the selected text with a function call using the function number instead of the function name.
+This activates support for quickly calling commonly used functions in the active language. `toggle funk` toggles showing the available common functions with associated numbers. `funk <user.code_common_function>` will insert the specified function call. `funk wrap <user.code_common_function>` wraps the currently selected text inside the function call. While the available common functions are being displayed, `funk cell <number>` and `funk wrap <number>` can be used for calling a function or wrapping the selected text with a function call using the function number from the graphical interface instead of the function name.
 
 ## user.code_data_null
 

--- a/docs/Voice Coding/snippets.md
+++ b/docs/Voice Coding/snippets.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Snippets
 
-Snippets insert text with placeholders such that you can get the next placeholder using the `snip next` command. You insert a snippet by saying `snip (snippet name)`.
+Snippets insert text with placeholders such that you can get the next placeholder using the `snip next` command. You insert a snippet by saying `snip {user.snippet}`.
 
 [This video](https://www.youtube.com/watch?v=icXH-o3mwTU) demonstrates snippets.
 

--- a/docs/Voice Coding/snippets.md
+++ b/docs/Voice Coding/snippets.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Snippets
 
-Snippets insert text with placeholders such that you can get the next placeholder using the `snip next` command. You insert a snippet by saying `snip {user.snippet}`.
+Snippets insert text with placeholders such that you can get the next placeholder using the `snip next` command. You insert a snippet by saying `snip {user.snippet}`, where a snippet name can be used in place of {user.snippet}. 
 
 [This video](https://www.youtube.com/watch?v=icXH-o3mwTU) demonstrates snippets.
 

--- a/docs/Voice Coding/voice-coding-overview.md
+++ b/docs/Voice Coding/voice-coding-overview.md
@@ -12,7 +12,7 @@ Talon community offers commands for inserting code in numerous languages. [Forma
 
 Community support for specific programming languages may be activated by voice commands, or via title tracking.
 
-The command `force {user.language_mode}` will activate the commands for the specified language globally, e.g. they'll work in any application. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
+The command `force {user.language_mode}` where a supported language name can be used in place of {user.language_mode} will activate the commands for the specified language in any application, e.g. `force python` to make python the active programming language. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
 
 By default, title tracking activates languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++ by automatically using the extension of the active file to infer the active programming language.
 

--- a/docs/Voice Coding/voice-coding-overview.md
+++ b/docs/Voice Coding/voice-coding-overview.md
@@ -12,7 +12,7 @@ Talon community offers commands for inserting code in numerous languages. [Forma
 
 Community support for specific programming languages may be activated by voice commands, or via title tracking.
 
-The command `force {user.language_mode}` where a supported language name can be used in place of {user.language_mode} will activate the commands for the specified language in any application, e.g. `force python` to make python the active programming language. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
+The command `force {user.language_mode}`, where a supported language name can be used in place of {user.language_mode}, will activate the commands for the specified language in any application, e.g. `force python` to make python the active programming language. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
 
 By default, title tracking activates languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++ by automatically using the extension of the active file to infer the active programming language.
 

--- a/docs/Voice Coding/voice-coding-overview.md
+++ b/docs/Voice Coding/voice-coding-overview.md
@@ -12,7 +12,7 @@ Talon community offers commands for inserting code in numerous languages. [Forma
 
 Community support for specific programming languages may be activated by voice commands, or via title tracking.
 
-The command `force (language name)` will activate the commands for the specified language globally, e.g. they'll work in any application. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
+The command `force {user.language_mode}` will activate the commands for the specified language globally, e.g. they'll work in any application. This will also disable the title tracking method until the `clear language modes` voice command is used to return to using automatic language activation.
 
 By default, title tracking activates languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++ by automatically using the extension of the active file to infer the active programming language.
 


### PR DESCRIPTION
Use the actual names for things used by community to make it easier to look things up instead of putting text descriptions like "language name". 