### PR TITLE
Revert estree-util-value-to-estree update from 3.1.0 to 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8686,12 +8686,12 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
-      "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.1.0.tgz",
+      "integrity": "sha512-608Ljjzmf3uOy19YczqzdX7keOJfC72CRKebDYxdPTZn2I+och7MOxh8F1fw9nwkgvNMrHNuGpYUsOTCoO5r2A==",
       "dependencies": {
-        "@types/estree": "^1.0.0"
+        "@types/estree": "^1.0.0",
+        "is-plain-obj": "^4.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/remcohaszing"


### PR DESCRIPTION
It breaks the diagram on the front page of the wiki.