### PR TITLE
Fix Mermaid colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@mdx-js/react": "^3.0.0",
         "@shikijs/rehype": "^3.1.0",
         "clsx": "^2.0.0",
+        "estree-util-value-to-estree": "^3.4.0",
+        "mermaid": "^11.10.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -289,9 +291,9 @@
       }
     },
     "node_modules/@antfu/utils": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-9.2.0.tgz",
-      "integrity": "sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
+      "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3984,18 +3986,18 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-A78CUEnFGX8I/WlILxJCuIJXloL0j/OJ9PSchPAfCargEIKmUBWvvEMmKWB5oONwiUqlNt+5eRufdkLxeHIWYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
       "license": "MIT",
       "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
-        "@antfu/utils": "^9.2.0",
+        "@antfu/install-pkg": "^1.0.0",
+        "@antfu/utils": "^8.1.0",
         "@iconify/types": "^2.0.0",
-        "debug": "^4.4.1",
-        "globals": "^15.15.0",
+        "debug": "^4.4.0",
+        "globals": "^15.14.0",
         "kolorist": "^1.8.0",
-        "local-pkg": "^1.1.1",
+        "local-pkg": "^1.0.0",
         "mlly": "^1.7.4"
       }
     },
@@ -8686,12 +8688,12 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.1.0.tgz",
-      "integrity": "sha512-608Ljjzmf3uOy19YczqzdX7keOJfC72CRKebDYxdPTZn2I+och7MOxh8F1fw9nwkgvNMrHNuGpYUsOTCoO5r2A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
+      "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "is-plain-obj": "^4.0.0"
+        "@types/estree": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/remcohaszing"
@@ -11171,15 +11173,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
+      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11617,13 +11619,13 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.11.0.tgz",
-      "integrity": "sha512-9lb/VNkZqWTRjVgCV+l1N+t4kyi94y+l5xrmBmbbxZYkfRl5hEDaTPMOcaWKCl1McG8nBEaMlWwkcAEEgjhBgg==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.10.1.tgz",
+      "integrity": "sha512-0PdeADVWURz7VMAX0+MiMcgfxFKY4aweSGsjgFihe3XlMKNqmai/cugMrqTd3WNHM93V+K+AZL6Wu6tB5HmxRw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.4",
-        "@iconify/utils": "^3.0.1",
+        "@iconify/utils": "^2.1.33",
         "@mermaid-js/parser": "^0.6.2",
         "@types/d3": "^7.4.3",
         "cytoscape": "^3.29.3",
@@ -11637,7 +11639,7 @@
         "katex": "^0.16.22",
         "khroma": "^2.1.0",
         "lodash-es": "^4.17.21",
-        "marked": "^15.0.7",
+        "marked": "^16.0.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@mdx-js/react": "^3.0.0",
     "@shikijs/rehype": "^3.1.0",
     "clsx": "^2.0.0",
+    "estree-util-value-to-estree": "^3.4.0",
+    "mermaid": "^11.10.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
The "all black" brokenness happened between Mermaid 11.10.1 and 11.11.0.

So, roll back to the most recent non-broken version.

Also revert my inappropriate rollback of estree-util-value-to-estree. I think netlify previews were rendering out of order so it looked like this was responsible, but it wasn't.
