### PR TITLE
Stop advertising settings register: Not part of public API, has performance implications

### DIFF
--- a/docs/Customization/Talon Framework/settings.md
+++ b/docs/Customization/Talon Framework/settings.md
@@ -46,14 +46,3 @@ ctx = Context()
 
 ctx.settings["user.my_user_file_set_horizontal_position"] = 50
 ```
-
-It is also possible to register a callback function to be called whenever a setting changes. This is done by calling settings.register() with a setting name and a function to call. If the name string is blank (like in the example below) then the callback function will be called whenever any setting is changed. When the name is not blank the function will only be called when a setting with a matching name is changed.
-
-`listener.py`
-
-```python
-def settings_change_handler(*args):
-    print("A setting has changed")
-
-settings.register("", settings_change_handler)
-```


### PR DESCRIPTION
Stop describing how to register a callback for when a setting changes on the wiki. Aegis has discouraged using this feature because this is not part of the public API and can have performance implications: https://talonvoice.slack.com/archives/C9MHQ4AGP/p1766608682484069?thread_ts=1766608544.979159&cid=C9MHQ4AGP