### PR TITLE
Fix key() action link in /Customization/talon-files

### DIFF
--- a/docs/Customization/talon-files.md
+++ b/docs/Customization/talon-files.md
@@ -280,6 +280,6 @@ key(f9:passive): app.notify("f9 pressed, and we won't stop any other apps from r
 key(f9:up): app.notify("show this balloon when the f9 key is released")
 ```
 
-The list of available keys you can listen to isn't well defined, but it is likely a subset of the names on the [key() action](Talon Library Reference/key_action.md) wiki page.
+The list of available keys you can listen to isn't well defined, but it is likely a subset of the names on the [`key()` action](./Talon%20Library%20Reference/key_action.md) wiki page.
 
 Aside from these, additional extra capabilities may be added from time to time. For example in the beta version you can currently define rules for matching facial expressions on OSX and user supplied noises (e.g. a whistle sound) via integration with parrot.py.


### PR DESCRIPTION
Fixes #388 

- Broken link fixed by URL encoding spaces.
- Also wrapped `key()` in backticks for formatting. That was not necessary to fix the link. I can revert that if undesired.
- Also added leading `./` to the link, since that seemed like the prevailing practice at a quick glance.