### PR TITLE
Authenticate GitHub API requests in build step to fix repo explorer errors

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build Docusaurus
         run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create CNAME file
         run: echo "talon.wiki" > ./build/CNAME


### PR DESCRIPTION
## Summary
- The `repo-data-plugin` fetches Talon repos from GitHub's Search API at build time, but the "Build Docusaurus" step never passed `GITHUB_TOKEN`, so requests went out unauthenticated (10 req/min, shared across every GitHub Actions runner's egress IP globally).
- Any other concurrent job on GitHub's shared infrastructure exhausting that quota would cause our fetch to fail. Since no build-time cache exists in CI (fresh checkout every run, `.docusaurus/` gitignored), the failure got baked directly into the deployed static site as "Error loading repositories" (https://talon.wiki/explorer/).
- Fix: pass the job's own ephemeral `GITHUB_TOKEN` into the build step's env, bumping the Search API budget to 30 req/min on a private, per-run quota rather than a globally shared one.

## Test plan
- [x] Confirmed locally that `GITHUB_TOKEN` correctly reaches the plugin and yields the higher authenticated rate-limit tier (`x-ratelimit-limit: 30` vs `10` unauthenticated, confirmed via live headers)
- [x] Confirmed unauthenticated build path still functions (it's not a hard failure locally, since the underlying bug is specific to shared/contended CI egress IPs, not reproducible from a single-tenant residential IP)
- [ ] After merge: verify the auto-triggered `Deploy to GitHub Pages` run completes cleanly and https://talon.wiki/explorer/ loads repository data with no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)